### PR TITLE
fix: Resolve bug where snapshot must be created after Confchange commit

### DIFF
--- a/examples/basic/main.py
+++ b/examples/basic/main.py
@@ -100,8 +100,9 @@ class HashStore(FSM):
             return pickle.dumps(self._store)
 
     async def restore(self, snapshot: bytes) -> None:
-        with self._lock:
-            self._store = pickle.loads(snapshot)
+        if snapshot:
+            with self._lock:
+                self._store = pickle.loads(snapshot)
 
 
 @routes.get("/get/{id}")

--- a/examples/joint-consensus/main.py
+++ b/examples/joint-consensus/main.py
@@ -105,8 +105,9 @@ class HashStore(FSM):
             return pickle.dumps(self._store)
 
     async def restore(self, snapshot: bytes) -> None:
-        with self._lock:
-            self._store = pickle.loads(snapshot)
+        if snapshot:
+            with self._lock:
+                self._store = pickle.loads(snapshot)
 
 
 @routes.get("/get/{id}")

--- a/raftify/mailbox.py
+++ b/raftify/mailbox.py
@@ -92,8 +92,10 @@ class Mailbox:
             )
             assert resp is not None
             return resp
-        except Exception as e:
-            self.logger.error("Error occurred while sending message through mailbox", e)
+        except Exception as err:
+            self.logger.error(
+                f"Error occurred while sending message through mailbox, {str(err)}"
+            )
             raise
 
     async def leave(self, node_id: int, addr: SocketAddr) -> None:

--- a/raftify/storage/lmdb.py
+++ b/raftify/storage/lmdb.py
@@ -15,6 +15,7 @@ from rraft import (
     HardStateRef,
     RaftState,
     Snapshot,
+    SnapshotMetadata,
     SnapshotRef,
     StoreError,
     UnavailableError,
@@ -265,6 +266,11 @@ class LMDBStorageCore:
 
             return entry.get_term() if entry else 0
 
+    def set_snapshot_metadata(self, metadata: SnapshotMetadata) -> None:
+        snapshot = self.snapshot(0, 0)
+        snapshot.set_metadata(metadata)
+        self.set_snapshot(snapshot)
+
 
 class LMDBStorage:
     def __init__(self, core: LMDBStorageCore, logger: AbstractRaftifyLogger):
@@ -335,6 +341,10 @@ class LMDBStorage:
     def snapshot(self, request_index: int, to: int) -> Snapshot:
         with Lock():
             return self.core.snapshot(request_index, to)
+
+    def set_snapshot_metadata(self, metadata: SnapshotMetadata) -> Snapshot:
+        with Lock():
+            return self.core.set_snapshot_metadata(metadata)
 
     def set_hard_state_comit(self, comit: int) -> None:
         with Lock():

--- a/tests/harness/store.py
+++ b/tests/harness/store.py
@@ -27,4 +27,5 @@ class HashStore(raftify.FSM):
         return pickle.dumps(self._store)
 
     async def restore(self, snapshot: bytes) -> None:
-        self._store = pickle.loads(snapshot)
+        if snapshot:
+            self._store = pickle.loads(snapshot)


### PR DESCRIPTION
In raft-rs, after `AddNode` entry is committed, `MsgSnapshot` message is sent.
At this time, the snapshot's `ConfState` needs to be updated.
However, this does not mean that the FSM's snapshot needs to be updated, and also there is no need to call `compact`.
This PR replaces `create_snapshot` with `update_snapshot_metadata` in `handle_committed_entries`.