### PR TITLE
feat: Reuses the gRPC connection whenever possible.

### DIFF
--- a/raftify/raft_client.py
+++ b/raftify/raft_client.py
@@ -21,12 +21,14 @@ class RaftClient:
         *,
         credentials: Optional[grpc.ServerCredentials] = None,
     ):
+        print("('@@@@@@ RaftClient created!!")
         if isinstance(addr, str):
             addr = SocketAddr.from_str(addr)
 
         self.addr = addr
         self.credentials = credentials
         self.first_failed_time: Optional[float] = None
+        self.connection = None
 
     def __repr__(self) -> str:
         return f"RaftClient(addr={self.addr})"
@@ -39,9 +41,43 @@ class RaftClient:
         }
 
     def __create_channel(self) -> grpc.aio.Channel:
-        if credentials := self.credentials:
-            return grpc.aio.secure_channel(str(self.addr), credentials)
-        return grpc.aio.insecure_channel(str(self.addr))
+        """
+        Creates or reuses a gRPC channel.
+        """
+
+        if self.connection:
+            try:
+                if (
+                    self.connection.get_state(try_to_connect=True)
+                    != grpc.ChannelConnectivity.READY
+                ):
+                    self.connection.close()
+                    self.connection = None
+            except Exception:
+                print('@@@@@@ Connection reset by error!!!!')
+                self.connection = None
+
+        if self.connection is None:
+            if credentials := self.credentials:
+                self.connection = grpc.aio.secure_channel(str(self.addr), credentials)
+            else:
+                print('@@@@@@ Channel generated!!!!')
+                self.connection = grpc.aio.insecure_channel(
+                    str(self.addr),
+                )
+
+        return self.connection
+
+    async def propose(
+        self, data: bytes, timeout: float = 5.0
+    ) -> raft_service_pb2.ProposeResponse:
+        """
+        Request to send a propose to the cluster.
+        """
+
+        request_args = raft_service_pb2.ProposeArgs(msg=data)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.Propose(request_args), timeout)
 
     async def change_config(
         self, conf_change: ConfChangeV2, timeout: float = math.inf
@@ -51,10 +87,11 @@ class RaftClient:
         """
 
         request_args = ConfChangeV2Adapter.to_pb(conf_change)
+        self.channel = self.__create_channel()
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.channel)
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.ChangeConfig(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.ChangeConfig(request_args), timeout)
 
     async def apply_change_config_forcely(
         self, conf_change: ConfChangeV2, timeout: float = math.inf
@@ -66,11 +103,10 @@ class RaftClient:
 
         request_args = ConfChangeV2Adapter.to_pb(conf_change)
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(
-                stub.ApplyConfigChangeForcely(request_args), timeout
-            )
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(
+            stub.ApplyConfigChangeForcely(request_args), timeout
+        )
 
     async def send_message(
         self, msg: Message, timeout: float = 5.0
@@ -82,22 +118,8 @@ class RaftClient:
 
         request_args = MessageAdapter.to_pb(msg)
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.SendMessage(request_args), timeout)
-
-    async def propose(
-        self, data: bytes, timeout: float = 5.0
-    ) -> raft_service_pb2.ProposeResponse:
-        """
-        Request to send a propose to the cluster.
-        """
-
-        request_args = raft_service_pb2.ProposeArgs(msg=data)
-
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.Propose(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.SendMessage(request_args), timeout)
 
     async def request_id(
         self, addr: SocketAddr, timeout: float = 5.0
@@ -108,9 +130,8 @@ class RaftClient:
 
         request_args = raft_service_pb2.IdRequestArgs(addr=str(addr))
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.RequestId(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.RequestId(request_args), timeout)
 
     async def member_bootstrap_ready(
         self, follower_id: int, timeout: float = 5.0
@@ -125,11 +146,10 @@ class RaftClient:
             follower_id=follower_id
         )
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(
-                stub.MemberBootstrapReady(request_args), timeout
-            )
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(
+            stub.MemberBootstrapReady(request_args), timeout
+        )
 
     async def cluster_bootstrap_ready(
         self, peers: bytes, timeout: float = 5.0
@@ -142,11 +162,10 @@ class RaftClient:
 
         request_args = raft_service_pb2.ClusterBootstrapReadyArgs(peers=peers)
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(
-                stub.ClusterBootstrapReady(request_args), timeout
-            )
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(
+            stub.ClusterBootstrapReady(request_args), timeout
+        )
 
     async def reroute_message(
         self,
@@ -165,9 +184,8 @@ class RaftClient:
             type=reroute_msg_type,
         )
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.RerouteMessage(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.RerouteMessage(request_args), timeout)
 
     async def debug_node(
         self, timeout: float = 5.0
@@ -178,9 +196,8 @@ class RaftClient:
 
         request_args = raft_service_pb2.Empty()
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.DebugNode(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.DebugNode(request_args), timeout)
 
     async def debug_entries(
         self, timeout: float = 5.0
@@ -191,9 +208,8 @@ class RaftClient:
 
         request_args = raft_service_pb2.Empty()
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.DebugEntries(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.DebugEntries(request_args), timeout)
 
     async def version(self, timeout: float = 5.0) -> raft_service_pb2.VersionResponse:
         """
@@ -202,9 +218,8 @@ class RaftClient:
 
         request_args = raft_service_pb2.Empty()
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.Version(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.Version(request_args), timeout)
 
     async def get_peers(
         self, timeout: float = 5.0
@@ -213,6 +228,5 @@ class RaftClient:
 
         request_args = raft_service_pb2.Empty()
 
-        async with self.__create_channel() as channel:
-            stub = raft_service_pb2_grpc.RaftServiceStub(channel)
-            return await asyncio.wait_for(stub.GetPeers(request_args), timeout)
+        stub = raft_service_pb2_grpc.RaftServiceStub(self.__create_channel())
+        return await asyncio.wait_for(stub.GetPeers(request_args), timeout)


### PR DESCRIPTION
This PR prevents network failures for repeated put requests by implementing a grpc channel reusing logic.

I manually tested through the following two examples.

## Example 1

```
#!/bin/bash

for i in {1..50000}
do
    curl -XGET "http://localhost:8001/put/$i/1"
done

```

## Example 2

```py
import asyncio
import pickle

from raftify.log_entry.set_command import SetCommand
from raftify.raft_client import RaftClient


async def main() -> None:
    """
    A simple set of commands to test and show usage of RaftClient.
    Please bootstrap the Raft cluster before running this script.
    """

    for _ in range(0, 50000):
        try:
            await RaftClient("127.0.0.1:60061").propose(SetCommand("1", "A").encode())
        except Exception:
            print('Connection error. continue...')
            continue

if __name__ == "__main__":
    asyncio.run(main())

```