### PR TITLE
fix: Remove unused import from `request/local_request_message.rs`

### DIFF
--- a/raftify/src/request/local_request_message.rs
+++ b/raftify/src/request/local_request_message.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use jopemachine_raft::eraftpb::{ConfChangeV2, Message as RaftMessage};
+use jopemachine_raft::eraftpb::Message as RaftMessage;
 use tokio::sync::oneshot::Sender;
 
 use crate::{


### PR DESCRIPTION
This pull request removes redundant imports from `request/local_request_message.rs`.

| Before | After |
| ------ | ------ |
| <img width="697" alt="스크린샷 2024-07-11 오전 11 11 51" src="https://github.com/lablup/raftify/assets/14137676/eaabad66-d573-42b0-b733-d6e47e02d063"> | <img width="697" alt="스크린샷 2024-07-11 오전 11 15 20" src="https://github.com/lablup/raftify/assets/14137676/55c2ae15-db29-4acd-aeed-553156f8ed18"> |
