### PR TITLE
refactor: `clap` upgrade to v4 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,34 +564,50 @@ dependencies = [
  "atty",
  "bitflags 1.3.2",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "strsim 0.10.0",
- "termcolor",
- "textwrap 0.16.1",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "color-backtrace"
@@ -553,6 +618,12 @@ dependencies = [
  "backtrace",
  "termcolor",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "const_format"
@@ -991,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "heed"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1262,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1466,12 +1549,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "page_size"
@@ -1766,7 +1843,7 @@ dependencies = [
  "built",
  "bytes",
  "chrono",
- "clap 3.2.25",
+ "clap 4.5.15",
  "heed",
  "heed-traits",
  "jopemachine-raft",
@@ -2104,9 +2181,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structopt"
@@ -2215,12 +2292,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -2570,6 +2641,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vec_map"

--- a/raftify/Cargo.toml
+++ b/raftify/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0"
 tokio = { version = "1.4", features = ["full"] }
 tonic = "0.9.2"
 built = "0.5"
-clap = "3.0"
+clap = { version = "4.5.15", features = ["derive"] }
 chrono = "0.4.31"
 
 [dev-dependencies]

--- a/raftify/src/cli/mod.rs
+++ b/raftify/src/cli/mod.rs
@@ -2,7 +2,7 @@ include!(concat!(env!("OUT_DIR"), "/built.rs"));
 
 mod commands;
 
-use clap::{App, Arg, SubCommand};
+use clap::{Args, Parser, Subcommand};
 use commands::{
     debug::{debug_entries, debug_node, debug_persisted, debug_persitsted_all},
     dump::dump_peers,
@@ -15,116 +15,103 @@ use crate::{
     AbstractLogEntry, AbstractStateMachine, CustomFormatter, Result,
 };
 
+/// It used nested subcommands struct, using clap 
+/// [`Commands`] -> represent functions
+/// [`DebugSubcommands`], [`Dump`] -> these parse additional factors for commands to use.
+/// if you enter the command like `raftify-cli debug persisted-all ./logs`
+/// it's expected [`App::command`] is debug, [`DebugSubcommands::PersistedAll::path`] is./logs
+#[derive(Parser)]
+#[command(name = "raftify")]
+#[command(version = PKG_VERSION)]
+#[command(author = PKG_AUTHORS)]
+#[command(about = PKG_DESCRIPTION)]
+struct App {
+    /// required main commands
+    #[command(subcommand)]
+    command: Commands,
+}
+
+// Subcommand Select
+#[derive(Subcommand)]
+enum Commands {
+    /// Debug tools
+    #[command(subcommand)]
+    Debug(DebugSubcommands),
+    /// Dump tools
+    Dump(Dump),
+    /// plz, list the following functions
+    Nan,
+}
+
+#[derive(Subcommand)]
+enum DebugSubcommands {
+    /// List persisted log entries and metadata
+    Persisted {
+        /// The log directory path
+        path: String,
+    },
+    /// List persisted log entries and metadata for all local nodes
+    PersistedAll {
+        /// The log directory path
+        path: String,
+    },
+    ///List all log entries
+    Entries {
+        /// The address of the RaftNode
+        address: String,
+    },
+    /// Inspect RaftNode
+    Node {
+        /// The address of the RaftNode
+        address: String,
+    },
+}
+
+#[derive(Args)]
+struct Dump {
+    /// The log directory path
+    path: String,
+    /// The peers to dump
+    peers: String,
+}
+
 pub async fn cli_handler<
     LogEntry: AbstractLogEntry + Debug + Send + 'static,
     FSM: AbstractStateMachine + Debug + Clone + Send + Sync + 'static,
 >(
-    custom_args: Option<Vec<String>>,
+    _custom_args: Option<Vec<String>>,
 ) -> Result<()> {
-    let app = App::new("raftify")
-        .version(PKG_VERSION)
-        .author(PKG_AUTHORS)
-        .about(PKG_DESCRIPTION)
-        .subcommand(
-            SubCommand::with_name("debug")
-                .about("Debug tools")
-                .subcommand(
-                    SubCommand::with_name("persisted")
-                        .about("List persisted log entries and metadata")
-                        .arg(
-                            Arg::with_name("path")
-                                .help("The log directory path")
-                                .required(true)
-                                .index(1),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("persisted-all")
-                        .about("List persisted log entries and metadata for all local nodes")
-                        .arg(
-                            Arg::with_name("path")
-                                .help("The log directory path")
-                                .required(true)
-                                .index(1),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("entries")
-                        .about("List all log entries")
-                        .arg(
-                            Arg::with_name("address")
-                                .help("The address of the RaftNode")
-                                .required(true)
-                                .index(1),
-                        ),
-                )
-                .subcommand(
-                    SubCommand::with_name("node").about("Inspect RaftNode").arg(
-                        Arg::with_name("address")
-                            .help("The address of the RaftNode")
-                            .required(true)
-                            .index(1),
-                    ),
-                ),
-        )
-        .subcommand(
-            SubCommand::with_name("dump")
-                .arg(
-                    Arg::with_name("path")
-                        .help("The log directory path")
-                        .required(true)
-                        .index(1),
-                )
-                .arg(
-                    Arg::with_name("peers")
-                        .help("The peers to dump")
-                        .required(true)
-                        .index(2),
-                )
-                .about(""),
-        );
-
-    let matches = match custom_args {
-        Some(args) => app.get_matches_from(args),
-        None => app.get_matches(),
-    };
-
+    // using env::args without '_custom_args'
+    let app = App::parse();
     let logger = default_logger();
     set_custom_formatter(CustomFormatter::<LogEntry, FSM>::new());
 
-    if let Some(("debug", debug_matches)) = matches.subcommand() {
-        match debug_matches.subcommand() {
-            Some(("entries", entries_matches)) => {
-                if let Some(address) = entries_matches.value_of("address") {
-                    debug_entries(address).await?;
-                }
+    match app.command {
+        Commands::Debug(x) => match x {
+            DebugSubcommands::Persisted { path } => {
+                debug_persisted(path.as_str(), logger.clone())?;
             }
-            Some(("node", node_matches)) => {
-                if let Some(address) = node_matches.value_of("address") {
-                    debug_node(address).await?;
-                }
+            DebugSubcommands::PersistedAll { path } => {
+                debug_persitsted_all(path.as_str(), logger.clone())?;
             }
-            Some(("persisted", persisted_matches)) => {
-                if let Some(path) = persisted_matches.value_of("path") {
-                    debug_persisted(path, logger.clone())?;
-                }
+            DebugSubcommands::Entries { address } => {
+                debug_entries(address.as_str()).await?;
             }
-            Some(("persisted-all", persisted_all_matches)) => {
-                if let Some(path) = persisted_all_matches.value_of("path") {
-                    debug_persitsted_all(path, logger.clone())?;
-                }
+            DebugSubcommands::Node { address } => {
+                debug_node(address.as_str()).await?;
             }
-            _ => {}
+        },
+        Commands::Dump(x) => {
+            dump_peers(
+                x.path.as_str(),
+                parse_peers_json(x.peers.as_str()).unwrap(),
+                logger.clone(),
+            )?;
         }
-    };
-
-    if let Some(("dump", dump_matches)) = matches.subcommand() {
-        if let Some(path) = dump_matches.value_of("path") {
-            if let Some(peers) = dump_matches.value_of("peers") {
-                dump_peers(path, parse_peers_json(peers).unwrap(), logger.clone())?;
-            }
+        _ => {
+            panic!("Command is not exist~");
         }
-    };
+    }
 
     Ok(())
 }

--- a/raftify/src/cli/mod.rs
+++ b/raftify/src/cli/mod.rs
@@ -15,19 +15,16 @@ use crate::{
     AbstractLogEntry, AbstractStateMachine, CustomFormatter, Result,
 };
 
-/// CLI parser 
 #[derive(Parser)]
 #[command(name = "raftify")]
 #[command(version = PKG_VERSION)]
 #[command(author = PKG_AUTHORS)]
 #[command(about = PKG_DESCRIPTION)]
 struct App {
-    /// required main commands
     #[command(subcommand)]
     command: Commands,
 }
 
-// Subcommand Select
 #[derive(Subcommand)]
 enum Commands {
     /// Debug tools
@@ -75,10 +72,8 @@ pub async fn cli_handler<
 >(
     args: Option<Vec<String>>,
 ) -> Result<()> {
-    let app: App = match args{
-        // using python side
+    let app: App = match args {
         Some(args) => App::parse_from(args),
-        // using env::args          
         None => App::parse(),
     };
     let logger = default_logger();


### PR DESCRIPTION
Previously, we were using `version 3 of Clap`, so we upgraded to `version 4`. However, this caused compile errors due to the version upgrade, leading us to remove a lot of legacy code and refactor the project.

Note) I tested the `debug` option as thoroughly as possible, but I was unable to test the `dump` option because I didn't know how to use it.