### PR TITLE
fix: Enhance snapshot deserializing panic error message

### DIFF
--- a/examples/memstore/src/state_machine.rs
+++ b/examples/memstore/src/state_machine.rs
@@ -55,7 +55,7 @@ impl AbstractStateMachine for HashStore {
     }
 
     async fn restore(&mut self, snapshot: Vec<u8>) -> Result<()> {
-        let new: HashMap<u64, String> = deserialize(&snapshot[..]).unwrap();
+        let new: HashMap<u64, String> = deserialize(&snapshot[..]).expect("Failed to restore state from snapshot: Snapshot data might be corrupted or incomplete");
         let mut db = self.0.write().unwrap();
         let _ = std::mem::replace(&mut *db, new);
         Ok(())


### PR DESCRIPTION
Modified the panic message for restoring a Node with a snapshot:
* Message before change: ```called Result::unwrap() on an Err value: Io(Kind(UnexpectedEof))```
* Message after change: ```Failed to restore state from snapshot: Snapshot data might be corrupted or incomplete: Io(Kind(UnexpectedEof))```
This change clarifies the error source when the restore function panics, making it easier to diagnose issues related to corrupted or incomplete snapshot data.