### PR TITLE
refactor: Make `raft-rs` as git submodule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
 
     - name: Build and Check Rust unit tests and harness tests all pass
       run: |
+        git submodule update --init
         make build
         make unit-test
         make integration-test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "raft-rs"]
+	path = raft-rs
+	url = https://github.com/jopemachine/raft-rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,6 +352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1309,9 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "jopemachine-raft"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c7ce3bb211baf0b188b4032f67dd45782e950a0a20f3bbf6035385f9921e2a"
+version = "0.7.7"
 dependencies = [
  "bytes",
  "fxhash",
@@ -1830,15 +1837,26 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-build"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
+checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
 dependencies = [
  "bitflags 1.3.2",
  "proc-macro2",
  "prost-build",
+ "protobuf-src",
  "quote",
+ "regex",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]
@@ -1853,8 +1871,6 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
 dependencies = [
  "lazy_static",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "jopemachine-raft"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "bytes",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "raft"
-version = "0.7.8"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "fxhash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,24 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jopemachine-raft"
-version = "0.7.8"
-dependencies = [
- "bytes",
- "fxhash",
- "getset",
- "lazy_static",
- "protobuf",
- "raft-proto",
- "rand",
- "slog",
- "slog-envlogger",
- "slog-stdlog",
- "slog-term",
- "thiserror",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1869,6 +1851,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "raft"
+version = "0.7.8"
+dependencies = [
+ "bytes",
+ "fxhash",
+ "getset",
+ "lazy_static",
+ "protobuf",
+ "raft-proto",
+ "rand",
+ "slog",
+ "slog-envlogger",
+ "slog-stdlog",
+ "slog-term",
+ "thiserror",
+]
+
+[[package]]
 name = "raft-proto"
 version = "0.7.0"
 dependencies = [
@@ -1890,10 +1890,10 @@ dependencies = [
  "clap 4.5.17",
  "heed",
  "heed-traits",
- "jopemachine-raft",
  "log",
  "parking_lot",
  "prost",
+ "raft",
  "serde",
  "serde_json",
  "slog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ default-members = [
     "examples/memstore/dynamic-members",
     "examples/memstore/static-members",
 ]
+exclude = ["raft-rs"]
 
 [workspace.package]
 version = "0.1.68"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,7 @@
+# Building from Source
+
+You can use this command to clone the repository:
+
+```
+❯ git clone --recursive https://github.com/lablup/raftify.git
+```

--- a/raftify/Cargo.toml
+++ b/raftify/Cargo.toml
@@ -18,7 +18,7 @@ heed-traits = "0.20"
 log = { version = "0.4", features = ["std"] }
 parking_lot = "0.12.1"
 prost = "0.11"
-jopemachine-raft = { path = "../raft-rs", features = ["prost-codec", "default-logger"], default-features = false }
+raft = { path = "../raft-rs", features = ["prost-codec", "default-logger"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2"

--- a/raftify/Cargo.toml
+++ b/raftify/Cargo.toml
@@ -18,7 +18,7 @@ heed-traits = "0.20"
 log = { version = "0.4", features = ["std"] }
 parking_lot = "0.12.1"
 prost = "0.11"
-jopemachine-raft = { version = "0.7.8", features = ["prost-codec", "default-logger"], default-features = false }
+jopemachine-raft = { path = "../raft-rs", features = ["prost-codec", "default-logger"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2"

--- a/raftify/build.rs
+++ b/raftify/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_client(true)
         .build_server(true)
-        .extern_path(".eraftpb", "::jopemachine_raft::eraftpb")
+        .extern_path(".eraftpb", "::raft::eraftpb")
         .compile(&["proto/raft_service.proto"], &["proto/"])?;
 
     built::write_built_file().expect("Failed to acquire build-time information");

--- a/raftify/src/lib.rs
+++ b/raftify/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate async_trait;
-
 mod config;
 mod error;
 mod formatter;
@@ -23,7 +20,7 @@ pub mod cluster_join_ticket;
 pub mod raft_service;
 
 pub use {
-    async_trait::async_trait, bincode, formatter::CustomFormatter, jopemachine_raft as raft,
+    async_trait::async_trait, bincode, formatter::CustomFormatter, raft,
     raft::Config as RaftConfig, tonic, tonic::transport::Channel,
 };
 

--- a/raftify/src/request/common/confchange_request.rs
+++ b/raftify/src/request/common/confchange_request.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 
-use jopemachine_raft::eraftpb::{self, ConfChangeSingle, ConfChangeTransition, ConfChangeV2};
-
+use crate::raft::eraftpb::{self, ConfChangeSingle, ConfChangeTransition, ConfChangeV2};
 use crate::raft_service;
 
 #[derive(Debug, Clone)]

--- a/raftify/src/request/local_request_message.rs
+++ b/raftify/src/request/local_request_message.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use jopemachine_raft::eraftpb::Message as RaftMessage;
+use crate::raft::eraftpb::Message as RaftMessage;
 use tokio::sync::oneshot::Sender;
 
 use crate::{

--- a/raftify/src/response/local_response_message.rs
+++ b/raftify/src/response/local_response_message.rs
@@ -1,6 +1,6 @@
 use std::{fmt, marker::PhantomData, sync::Arc};
 
-use jopemachine_raft::RawNode;
+use crate::raft::RawNode;
 use tokio::sync::Mutex;
 
 use crate::{AbstractLogEntry, AbstractStateMachine, HeedStorage, Peers};

--- a/raftify/src/state_machine/mod.rs
+++ b/raftify/src/state_machine/mod.rs
@@ -1,3 +1,5 @@
+use tonic::async_trait;
+
 use crate::Result;
 
 #[async_trait]


### PR DESCRIPTION
There are many cases where we need to delve into and even modify the internal code of the raft-rs module.

In that sense, it might be a good idea to include the raft-rs module in the repository.

But including the module itself as a directory can make it somewhat cumbersome to track changes in the module itself, so let's manage the raft-rs directory in a separate repository and add that repository as a submodule.