### PR TITLE
fix: Change http method GET -> PUT in python binding web server api

### DIFF
--- a/binding/python/examples/web_server_api.py
+++ b/binding/python/examples/web_server_api.py
@@ -42,7 +42,7 @@ async def get(request: web.Request) -> web.Response:
     return web.Response(text=store.get(id))
 
 
-@routes.get("/put/{id}/{value}")
+@routes.put("/{id}/{value}")
 async def put(request: web.Request) -> web.Response:
     raft: Raft = request.app["state"]["raft"]
     id, value = request.match_info["id"], request.match_info["value"]


### PR DESCRIPTION
### Change
- related: https://github.com/lablup/raftify/pull/114
- Change HTTP method of the same function in python binding's web server api code.

### Test
- After the change, I've checked using curl:
```
➜  /python git:(main) ✗ curl -X GET 'http://127.0.0.1:8003/put/1/999'
404: Not Found%
➜  /python git:(main) ✗ curl -X PUT 'http://127.0.0.1:8003/1/999'
OK%
➜  /python git:(main) ✗ curl -X GET 'http://127.0.0.1:8003/get/1'
999%
```