### PR TITLE
feat: Add logging level to python bindings

### DIFF
--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -72,6 +72,34 @@ class ReadOnlyOption:
     in that case.
     """
 
+class Level:
+    DEBUG: Final
+    """
+    Detailed information, typically only of interest to a developer trying to diagnose a problem.
+    """
+
+    INFO: Final
+    """
+    Confirmation that things are working as expected.
+    """
+
+    WARNING: Final
+    """ 
+    An indication that something unexpected happened, or that a problem might occur in the near future (e.g. ‘disk space low’). 
+    The software is still working as expected. 
+    """
+
+    ERROR: Final
+    """ 
+    Due to a more serious problem, the software has not been able to perform some function.
+    """
+
+    CRITICAL: Final
+
+    """ 
+    A serious error, indicating that the program itself may be unable to continue running.
+    """
+
 class Slogger:
     """ """
 
@@ -80,7 +108,11 @@ class Slogger:
     def default() -> "Slogger": ...
     @staticmethod
     def new_file_logger(
-        level: int, log_path: str, chan_size: int, rotate_size: int, rotate_keep: int
+        log_path: str,
+        level: "Level" = Level.DEBUG,
+        chan_size: int = 3000,
+        rotate_size: int = 1024 * 1024 * 10,
+        rotate_keep: int = 1,
     ): ...
 
 class Raft:

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -73,6 +73,12 @@ class ReadOnlyOption:
     """
 
 class Severity:
+    """
+    Setting the logger level for slog crate.
+
+    Note: Currently, it can only be applied to FileLogger.
+    """
+
     DEBUG: Final[Any]
     """
     """
@@ -82,16 +88,16 @@ class Severity:
     """
 
     WARNING: Final[Any]
-    """ 
+    """
     """
 
     ERROR: Final[Any]
-    """ 
+    """
     """
 
     CRITICAL: Final[Any]
 
-    """ 
+    """
     """
 
 class Slogger:

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -73,28 +73,28 @@ class ReadOnlyOption:
     """
 
 class Level:
-    DEBUG: Final
+    DEBUG: Final[Any]
     """
     Detailed information, typically only of interest to a developer trying to diagnose a problem.
     """
 
-    INFO: Final
+    INFO: Final[Any]
     """
     Confirmation that things are working as expected.
     """
 
-    WARNING: Final
+    WARNING: Final[Any]
     """ 
     An indication that something unexpected happened, or that a problem might occur in the near future (e.g. ‘disk space low’). 
     The software is still working as expected. 
     """
 
-    ERROR: Final
+    ERROR: Final[Any]
     """ 
     Due to a more serious problem, the software has not been able to perform some function.
     """
 
-    CRITICAL: Final
+    CRITICAL: Final[Any]
 
     """ 
     A serious error, indicating that the program itself may be unable to continue running.

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -3,16 +3,13 @@ from typing import Any, Callable, Final, Optional
 
 # TODO: Make these abstract types available in the Python side.
 
-
 class AbstractLogEntry(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
-
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractLogEntry":
         raise NotImplementedError
-
 
 class AbstractStateMachine(metaclass=abc.ABCMeta):
     """
@@ -24,49 +21,38 @@ class AbstractStateMachine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def apply(self, message: bytes) -> bytes:
         raise NotImplementedError
-
     @abc.abstractmethod
     async def snapshot(self) -> bytes:
         raise NotImplementedError
-
     @abc.abstractmethod
     async def restore(self, snapshot: bytes) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
-
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractStateMachine":
         raise NotImplementedError
-
 
 class AbstractLogger(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def info(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def debug(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def trace(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def error(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def warn(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def fatal(self, s: str) -> None:
         raise NotImplementedError
-
 
 class ReadOnlyOption:
     """Determines the relative safety of and consistency of read only requests."""
@@ -85,7 +71,6 @@ class ReadOnlyOption:
     should (clock can move backward/pause without any bound). ReadIndex is not safe
     in that case.
     """
-
 
 class Level:
     DEBUG: Final[Any]
@@ -109,14 +94,12 @@ class Level:
     """ 
     """
 
-
 class Slogger:
     """ """
 
     def __init__(self) -> None: ...
     @staticmethod
     def default() -> "Slogger": ...
-
     @staticmethod
     def new_file_logger(
         log_path: str,
@@ -125,7 +108,6 @@ class Slogger:
         rotate_size: int,
         rotate_keep: int = 1,
     ): ...
-
 
 class Raft:
     def __init__(self) -> None:
@@ -139,69 +121,49 @@ class Raft:
         logger: "AbstractLogger",
     ) -> "Raft":
         """ """
-
     def get_raft_node(self) -> "RaftNode":
         """ """
     @staticmethod
     async def request_id(raft_addr: str, peer_addr: str) -> "ClusterJoinTicket":
         """"""
-
     async def run(self) -> None:
         """ """
-
 
 class RaftNode:
     async def is_leader(self) -> bool:
         """ """
-
     async def get_id(self) -> int:
         """ """
-
     async def get_leader_id(self) -> int:
         """ """
-
     async def get_peers(self) -> "Peers":
         """ """
-
     async def add_peer(self, id: int, addr: str) -> None:
         """ """
-
     async def inspect(self) -> str:
         """ """
-
     async def propose(self, message: bytes) -> None:
         """ """
-
     async def change_config(self, conf_change: "ConfChangeV2") -> None:
         """ """
-
     async def send_message(self, message: "Message") -> None:
         """ """
-
     async def leave(self) -> None:
         """ """
-
     async def leave_joint(self) -> None:
         """ """
-
     async def demote(self, term: int, leader_id: int) -> None:
         """ """
-
     async def transfer_leader(self, leader_id: int) -> None:
         """ """
-
     async def quit(self) -> None:
         """ """
-
     async def join_cluster(self, tickets: list["ClusterJoinTicket"]) -> None:
         """ """
-
     async def get_cluster_size(self) -> int:
         """ """
-
     async def state_machine(self) -> "AbstractStateMachine":
         """ """
-
 
 class ClusterJoinTicket:
     """ """
@@ -213,16 +175,13 @@ class ClusterJoinTicket:
         leader_addr: str,
         peers: "Peers",
     ) -> None: ...
-
     def get_reserved_id(self) -> int:
         """ """
-
     def to_dict(self) -> dict[str, Any]:
         """ """
     @staticmethod
     def from_dict(v: dict[str, Any]) -> "ClusterJoinTicket":
         """ """
-
 
 class Peer:
     """ """
@@ -232,7 +191,6 @@ class Peer:
     def get_role(self) -> "InitialRole": ...
     async def connect(self) -> None: ...
 
-
 class Peers:
     """ """
 
@@ -241,12 +199,9 @@ class Peers:
     def is_empty(self) -> bool: ...
     def keys(self) -> list[int]: ...
     def get(self, node_id: int) -> "Peer": ...
-    def add_peer(self, node_id: int, addr: str,
-                 role: "InitialRole") -> None: ...
-
+    def add_peer(self, node_id: int, addr: str, role: "InitialRole") -> None: ...
     def remove(self, node_id: int) -> None: ...
     def get_node_id_by_addr(self, addr: str) -> int: ...
-
 
 class RaftConfig:
     """ """
@@ -330,7 +285,6 @@ class RaftConfig:
         :param max_committed_size_per_ready: Max size for committed entries in a `Ready`.
         """
 
-
 class Config:
     """ """
 
@@ -353,11 +307,9 @@ class Config:
     ) -> None:
         """ """
 
-
 class ConfChangeRequest:
     def __init__(self, changes: list["ConfChangeSingle"], addrs: list[str]) -> None:
         """ """
-
 
 class RaftServiceClient:
     """ """
@@ -365,66 +317,50 @@ class RaftServiceClient:
     @staticmethod
     async def build(addr: str) -> "RaftServiceClient":
         """ """
-
     async def change_config(self, conf_change: "ConfChangeRequest") -> None:
         """ """
-
     async def send_message(self, message: "Message") -> None:
         """ """
-
     async def propose(self, proposal: bytes) -> None:
         """ """
-
     async def get_peers(self) -> str:
         """ """
-
     async def set_peers(self, peers: "Peers") -> None:
         """ """
-
     async def leave_joint(self) -> None:
         """ """
-
     async def debug_node(self) -> str:
         """ """
-
 
 def set_snapshot_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
-
 def set_message_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
-
 
 def set_confchange_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
-
 def set_confchangev2_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
-
 def set_entry_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
-
 def set_entry_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
-
 
 def set_fsm_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
 
-
 def set_log_entry_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
-
 
 class ConfChangeTransition:
     """ """
@@ -457,7 +393,6 @@ class ConfChangeTransition:
     def from_int(v: int) -> "ConfChangeTransition": ...
     def __int__(self) -> int: ...
 
-
 class MessageType:
     """ """
 
@@ -484,7 +419,6 @@ class MessageType:
     def from_int(v: int) -> "MessageType": ...
     def __int__(self) -> int: ...
 
-
 class ConfChangeType:
     """ """
 
@@ -495,7 +429,6 @@ class ConfChangeType:
     def from_int(v: int) -> "ConfChangeType": ...
     def __int__(self) -> int: ...
 
-
 class EntryType:
     """ """
 
@@ -505,7 +438,6 @@ class EntryType:
     @staticmethod
     def from_int(v: int) -> "EntryType": ...
     def __int__(self) -> int: ...
-
 
 class InitialRole:
     """ """
@@ -523,52 +455,38 @@ class InitialRole:
     def from_str(v: str) -> "InitialRole": ...
     def __int__(self) -> int: ...
 
-
 class Entry:
     def __init__(self) -> None: ...
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_data(self) -> bytes:
         """ """
-
     def set_data(self, data: bytes) -> None:
         """ """
-
     def get_entry_type(self) -> "EntryType":
         """ """
-
     def set_entry_type(self, type_: "EntryType") -> None:
         """ """
-
     def get_term(self) -> int:
         """ """
-
     def set_term(self, term: int) -> None:
         """ """
-
     def get_index(self) -> int:
         """ """
-
     def set_index(self, index: int) -> None:
         """ """
-
     def get_sync_log(self) -> bool:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
-
     def set_sync_log(self, sync_log: bool) -> None:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
-
 
 class ConfState:
     """ """
@@ -578,135 +496,98 @@ class ConfState:
     ) -> None: ...
     @staticmethod
     def default() -> "ConfState": ...
-
     def get_auto_leave(self) -> bool:
         """ """
-
     def set_auto_leave(self, auto_leave: bool) -> None:
         """ """
-
     def get_learners(self) -> list[int]:
         """ """
-
     def set_learners(self, learners: list[int]) -> None:
         """ """
-
     def get_learners_next(self) -> list[int]:
         """ """
-
     def set_learners_next(self, learners_next: list[int]) -> None:
         """ """
-
     def get_voters(self) -> list[int]:
         """ """
-
     def set_voters(self, voters: list[int]) -> None:
         """ """
-
     def get_voters_outgoing(self) -> list[int]:
         """ """
-
     def set_voters_outgoing(self, voters_outgoing: list[int]) -> None:
         """ """
-
 
 class Snapshot:
     """ """
 
     def __init__(self) -> None: ...
-
     def get_data(self) -> bytes:
         """ """
-
     def set_data(self, data: bytes) -> None:
         """ """
-
     def get_metadata(self) -> "SnapshotMetadata":
         """ """
-
     def set_metadata(self, metadata: "SnapshotMetadata") -> None:
         """ """
-
     def has_metadata(self) -> bool:
         """ """
 
-
 class SnapshotMetadata:
     def __init__(self) -> None: ...
-
     def get_index(self) -> int:
         """
         `index`: The applied index.
         """
-
     def set_index(self, index: int) -> None:
         """
         `index`: The applied index.
         """
-
     def get_term(self) -> int:
         """
         `term`: The term of the applied index.
         """
-
     def set_term(self, term: int) -> None:
         """
         `term`: The term of the applied index.
         """
-
     def get_conf_state(self) -> "ConfState":
         """
         `conf_state`: The current `ConfState`.
         """
-
     def set_conf_state(self, conf_state: "ConfState") -> None:
         """
         `conf_state`: The current `ConfState`.
         """
-
     def has_conf_state(self) -> bool:
         """
         `conf_state`: The current `ConfState`.
         """
 
-
 class ConfChangeSingle:
     def __init__(self) -> None: ...
-
     def get_node_id(self) -> int:
         """ """
-
     def set_node_id(self, node_id: int):
         """ """
-
     def get_change_type(self) -> "ConfChangeType":
         """ """
-
     def set_change_type(self, type_: "ConfChangeType") -> None:
         """ """
 
-
 class ConfChangeV2:
     def __init__(self) -> None: ...
-
     def get_changes(self) -> list["ConfChangeSingle"]:
         """ """
-
     def set_changes(self, changes: list["ConfChangeSingle"]) -> None:
         """ """
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_transition(self) -> "ConfChangeTransition":
         """ """
-
     def set_transition(self, transition: "ConfChangeTransition") -> None:
         """ """
-
     def enter_joint(self) -> Optional[bool]:
         """
         Checks if uses Joint Consensus.
@@ -716,7 +597,6 @@ class ConfChangeV2:
         Consensus was requested explicitly. The bool indicates whether the Joint State
         will be left automatically.
         """
-
     def leave_joint(self) -> bool:
         """
         Checks if the configuration change leaves a joint configuration.
@@ -725,109 +605,74 @@ class ConfChangeV2:
         the Context field.
         """
 
-
 class Message:
     def __init__(self) -> None: ...
-
     def get_commit(self) -> int:
         """ """
-
     def set_commit(self, commit: int) -> None:
         """ """
-
     def get_commit_term(self) -> int:
         """ """
-
     def set_commit_term(self, commit_term: int) -> None:
         """ """
-
     def get_from(self) -> int:
         """ """
-
     def set_from(self, from_: int) -> None:
         """ """
-
     def get_index(self) -> int:
         """ """
-
     def set_index(self, index: int) -> None:
         """ """
-
     def get_term(self) -> int:
         """ """
-
     def set_term(self, term: int) -> None:
         """ """
-
     def get_log_term(self) -> int:
         """ """
-
     def set_log_term(self, log_index: int) -> None:
         """ """
-
     def get_priority(self) -> int:
         """ """
-
     def set_priority(self, priority: int) -> None:
         """ """
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_reject_hint(self) -> int:
         """ """
-
     def set_reject_hint(self, reject_hint: int) -> None:
         """ """
-
     def get_entries(self) -> list["Entry"]:
         """ """
-
     def set_entries(self, entries: list["Entry"]) -> None:
         """ """
-
     def get_msg_type(self) -> "MessageType":
         """ """
-
     def set_msg_type(self, type_: "MessageType") -> None:
         """ """
-
     def get_reject(self) -> bool:
         """ """
-
     def set_reject(self, reject: bool) -> None:
         """ """
-
     def get_snapshot(self) -> "Snapshot":
         """ """
-
     def set_snapshot(self, snapshot: "Snapshot") -> None:
         """ """
-
     def get_to(self) -> int:
         """ """
-
     def set_to(self, to: int) -> None:
         """ """
-
     def get_request_snapshot(self) -> int:
         """ """
-
     def set_request_snapshot(self, request_snapshot: int) -> None:
         """ """
-
     def has_snapshot(self) -> bool:
         """ """
-
     def get_deprecated_priority(self) -> int:
         """ """
-
     def set_deprecated_priority(self, deprecated_priority: int) -> None:
         """ """
-
 
 async def cli_main(argv: list[str]) -> None:
     """ """

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -78,6 +78,10 @@ class Severity:
     Note: Currently, it can only be applied to FileLogger.
     """
 
+    TRACE: Final[Any]
+    """
+    """
+
     DEBUG: Final[Any]
     """
     """

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -2,13 +2,17 @@ import abc
 from typing import Any, Callable, Final, Optional
 
 # TODO: Make these abstract types available in the Python side.
+
+
 class AbstractLogEntry(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
+
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractLogEntry":
         raise NotImplementedError
+
 
 class AbstractStateMachine(metaclass=abc.ABCMeta):
     """
@@ -20,38 +24,49 @@ class AbstractStateMachine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def apply(self, message: bytes) -> bytes:
         raise NotImplementedError
+
     @abc.abstractmethod
     async def snapshot(self) -> bytes:
         raise NotImplementedError
+
     @abc.abstractmethod
     async def restore(self, snapshot: bytes) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
+
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractStateMachine":
         raise NotImplementedError
+
 
 class AbstractLogger(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def info(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def debug(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def trace(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def error(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def warn(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def fatal(self, s: str) -> None:
         raise NotImplementedError
+
 
 class ReadOnlyOption:
     """Determines the relative safety of and consistency of read only requests."""
@@ -71,16 +86,19 @@ class ReadOnlyOption:
     in that case.
     """
 
+
 class Slogger:
     """ """
 
     def __init__(self) -> None: ...
     @staticmethod
     def default() -> "Slogger": ...
+
     @staticmethod
     def new_file_logger(
-        log_path: str, chan_size: int, rotate_size: int, rotate_keep: int
+        level: int, log_path: str, chan_size: int, rotate_size: int, rotate_keep: int
     ): ...
+
 
 class Raft:
     def __init__(self) -> None:
@@ -94,49 +112,69 @@ class Raft:
         logger: "AbstractLogger",
     ) -> "Raft":
         """ """
+
     def get_raft_node(self) -> "RaftNode":
         """ """
     @staticmethod
     async def request_id(raft_addr: str, peer_addr: str) -> "ClusterJoinTicket":
         """"""
+
     async def run(self) -> None:
         """ """
+
 
 class RaftNode:
     async def is_leader(self) -> bool:
         """ """
+
     async def get_id(self) -> int:
         """ """
+
     async def get_leader_id(self) -> int:
         """ """
+
     async def get_peers(self) -> "Peers":
         """ """
+
     async def add_peer(self, id: int, addr: str) -> None:
         """ """
+
     async def inspect(self) -> str:
         """ """
+
     async def propose(self, message: bytes) -> None:
         """ """
+
     async def change_config(self, conf_change: "ConfChangeV2") -> None:
         """ """
+
     async def send_message(self, message: "Message") -> None:
         """ """
+
     async def leave(self) -> None:
         """ """
+
     async def leave_joint(self) -> None:
         """ """
+
     async def demote(self, term: int, leader_id: int) -> None:
         """ """
+
     async def transfer_leader(self, leader_id: int) -> None:
         """ """
+
     async def quit(self) -> None:
         """ """
+
     async def join_cluster(self, tickets: list["ClusterJoinTicket"]) -> None:
         """ """
+
     async def get_cluster_size(self) -> int:
         """ """
+
     async def state_machine(self) -> "AbstractStateMachine":
         """ """
+
 
 class ClusterJoinTicket:
     """ """
@@ -148,13 +186,16 @@ class ClusterJoinTicket:
         leader_addr: str,
         peers: "Peers",
     ) -> None: ...
+
     def get_reserved_id(self) -> int:
         """ """
+
     def to_dict(self) -> dict[str, Any]:
         """ """
     @staticmethod
     def from_dict(v: dict[str, Any]) -> "ClusterJoinTicket":
         """ """
+
 
 class Peer:
     """ """
@@ -164,6 +205,7 @@ class Peer:
     def get_role(self) -> "InitialRole": ...
     async def connect(self) -> None: ...
 
+
 class Peers:
     """ """
 
@@ -172,9 +214,12 @@ class Peers:
     def is_empty(self) -> bool: ...
     def keys(self) -> list[int]: ...
     def get(self, node_id: int) -> "Peer": ...
-    def add_peer(self, node_id: int, addr: str, role: "InitialRole") -> None: ...
+    def add_peer(self, node_id: int, addr: str,
+                 role: "InitialRole") -> None: ...
+
     def remove(self, node_id: int) -> None: ...
     def get_node_id_by_addr(self, addr: str) -> int: ...
+
 
 class RaftConfig:
     """ """
@@ -258,6 +303,7 @@ class RaftConfig:
         :param max_committed_size_per_ready: Max size for committed entries in a `Ready`.
         """
 
+
 class Config:
     """ """
 
@@ -280,9 +326,11 @@ class Config:
     ) -> None:
         """ """
 
+
 class ConfChangeRequest:
     def __init__(self, changes: list["ConfChangeSingle"], addrs: list[str]) -> None:
         """ """
+
 
 class RaftServiceClient:
     """ """
@@ -290,50 +338,66 @@ class RaftServiceClient:
     @staticmethod
     async def build(addr: str) -> "RaftServiceClient":
         """ """
+
     async def change_config(self, conf_change: "ConfChangeRequest") -> None:
         """ """
+
     async def send_message(self, message: "Message") -> None:
         """ """
+
     async def propose(self, proposal: bytes) -> None:
         """ """
+
     async def get_peers(self) -> str:
         """ """
+
     async def set_peers(self, peers: "Peers") -> None:
         """ """
+
     async def leave_joint(self) -> None:
         """ """
+
     async def debug_node(self) -> str:
         """ """
+
 
 def set_snapshot_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
+
 def set_message_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
+
 
 def set_confchange_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
+
 def set_confchangev2_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
+
 def set_entry_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
+
 def set_entry_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
+
 
 def set_fsm_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
 
+
 def set_log_entry_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
+
 
 class ConfChangeTransition:
     """ """
@@ -366,6 +430,7 @@ class ConfChangeTransition:
     def from_int(v: int) -> "ConfChangeTransition": ...
     def __int__(self) -> int: ...
 
+
 class MessageType:
     """ """
 
@@ -392,6 +457,7 @@ class MessageType:
     def from_int(v: int) -> "MessageType": ...
     def __int__(self) -> int: ...
 
+
 class ConfChangeType:
     """ """
 
@@ -402,6 +468,7 @@ class ConfChangeType:
     def from_int(v: int) -> "ConfChangeType": ...
     def __int__(self) -> int: ...
 
+
 class EntryType:
     """ """
 
@@ -411,6 +478,7 @@ class EntryType:
     @staticmethod
     def from_int(v: int) -> "EntryType": ...
     def __int__(self) -> int: ...
+
 
 class InitialRole:
     """ """
@@ -428,38 +496,52 @@ class InitialRole:
     def from_str(v: str) -> "InitialRole": ...
     def __int__(self) -> int: ...
 
+
 class Entry:
     def __init__(self) -> None: ...
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_data(self) -> bytes:
         """ """
+
     def set_data(self, data: bytes) -> None:
         """ """
+
     def get_entry_type(self) -> "EntryType":
         """ """
+
     def set_entry_type(self, type_: "EntryType") -> None:
         """ """
+
     def get_term(self) -> int:
         """ """
+
     def set_term(self, term: int) -> None:
         """ """
+
     def get_index(self) -> int:
         """ """
+
     def set_index(self, index: int) -> None:
         """ """
+
     def get_sync_log(self) -> bool:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
+
     def set_sync_log(self, sync_log: bool) -> None:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
+
 
 class ConfState:
     """ """
@@ -469,98 +551,135 @@ class ConfState:
     ) -> None: ...
     @staticmethod
     def default() -> "ConfState": ...
+
     def get_auto_leave(self) -> bool:
         """ """
+
     def set_auto_leave(self, auto_leave: bool) -> None:
         """ """
+
     def get_learners(self) -> list[int]:
         """ """
+
     def set_learners(self, learners: list[int]) -> None:
         """ """
+
     def get_learners_next(self) -> list[int]:
         """ """
+
     def set_learners_next(self, learners_next: list[int]) -> None:
         """ """
+
     def get_voters(self) -> list[int]:
         """ """
+
     def set_voters(self, voters: list[int]) -> None:
         """ """
+
     def get_voters_outgoing(self) -> list[int]:
         """ """
+
     def set_voters_outgoing(self, voters_outgoing: list[int]) -> None:
         """ """
+
 
 class Snapshot:
     """ """
 
     def __init__(self) -> None: ...
+
     def get_data(self) -> bytes:
         """ """
+
     def set_data(self, data: bytes) -> None:
         """ """
+
     def get_metadata(self) -> "SnapshotMetadata":
         """ """
+
     def set_metadata(self, metadata: "SnapshotMetadata") -> None:
         """ """
+
     def has_metadata(self) -> bool:
         """ """
 
+
 class SnapshotMetadata:
     def __init__(self) -> None: ...
+
     def get_index(self) -> int:
         """
         `index`: The applied index.
         """
+
     def set_index(self, index: int) -> None:
         """
         `index`: The applied index.
         """
+
     def get_term(self) -> int:
         """
         `term`: The term of the applied index.
         """
+
     def set_term(self, term: int) -> None:
         """
         `term`: The term of the applied index.
         """
+
     def get_conf_state(self) -> "ConfState":
         """
         `conf_state`: The current `ConfState`.
         """
+
     def set_conf_state(self, conf_state: "ConfState") -> None:
         """
         `conf_state`: The current `ConfState`.
         """
+
     def has_conf_state(self) -> bool:
         """
         `conf_state`: The current `ConfState`.
         """
 
+
 class ConfChangeSingle:
     def __init__(self) -> None: ...
+
     def get_node_id(self) -> int:
         """ """
+
     def set_node_id(self, node_id: int):
         """ """
+
     def get_change_type(self) -> "ConfChangeType":
         """ """
+
     def set_change_type(self, type_: "ConfChangeType") -> None:
         """ """
 
+
 class ConfChangeV2:
     def __init__(self) -> None: ...
+
     def get_changes(self) -> list["ConfChangeSingle"]:
         """ """
+
     def set_changes(self, changes: list["ConfChangeSingle"]) -> None:
         """ """
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_transition(self) -> "ConfChangeTransition":
         """ """
+
     def set_transition(self, transition: "ConfChangeTransition") -> None:
         """ """
+
     def enter_joint(self) -> Optional[bool]:
         """
         Checks if uses Joint Consensus.
@@ -570,6 +689,7 @@ class ConfChangeV2:
         Consensus was requested explicitly. The bool indicates whether the Joint State
         will be left automatically.
         """
+
     def leave_joint(self) -> bool:
         """
         Checks if the configuration change leaves a joint configuration.
@@ -578,74 +698,109 @@ class ConfChangeV2:
         the Context field.
         """
 
+
 class Message:
     def __init__(self) -> None: ...
+
     def get_commit(self) -> int:
         """ """
+
     def set_commit(self, commit: int) -> None:
         """ """
+
     def get_commit_term(self) -> int:
         """ """
+
     def set_commit_term(self, commit_term: int) -> None:
         """ """
+
     def get_from(self) -> int:
         """ """
+
     def set_from(self, from_: int) -> None:
         """ """
+
     def get_index(self) -> int:
         """ """
+
     def set_index(self, index: int) -> None:
         """ """
+
     def get_term(self) -> int:
         """ """
+
     def set_term(self, term: int) -> None:
         """ """
+
     def get_log_term(self) -> int:
         """ """
+
     def set_log_term(self, log_index: int) -> None:
         """ """
+
     def get_priority(self) -> int:
         """ """
+
     def set_priority(self, priority: int) -> None:
         """ """
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_reject_hint(self) -> int:
         """ """
+
     def set_reject_hint(self, reject_hint: int) -> None:
         """ """
+
     def get_entries(self) -> list["Entry"]:
         """ """
+
     def set_entries(self, entries: list["Entry"]) -> None:
         """ """
+
     def get_msg_type(self) -> "MessageType":
         """ """
+
     def set_msg_type(self, type_: "MessageType") -> None:
         """ """
+
     def get_reject(self) -> bool:
         """ """
+
     def set_reject(self, reject: bool) -> None:
         """ """
+
     def get_snapshot(self) -> "Snapshot":
         """ """
+
     def set_snapshot(self, snapshot: "Snapshot") -> None:
         """ """
+
     def get_to(self) -> int:
         """ """
+
     def set_to(self, to: int) -> None:
         """ """
+
     def get_request_snapshot(self) -> int:
         """ """
+
     def set_request_snapshot(self, request_snapshot: int) -> None:
         """ """
+
     def has_snapshot(self) -> bool:
         """ """
+
     def get_deprecated_priority(self) -> int:
         """ """
+
     def set_deprecated_priority(self, deprecated_priority: int) -> None:
         """ """
+
 
 async def cli_main(argv: list[str]) -> None:
     """ """

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -2,7 +2,6 @@ import abc
 from typing import Any, Callable, Final, Optional
 
 # TODO: Make these abstract types available in the Python side.
-
 class AbstractLogEntry(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def encode(self) -> bytes:
@@ -112,7 +111,7 @@ class Slogger:
         level: "Severity",
         chan_size: int,
         rotate_size: int,
-        rotate_keep: int = 1,
+        rotate_keep: int,
     ): ...
 
 class Raft:

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -72,7 +72,7 @@ class ReadOnlyOption:
     in that case.
     """
 
-class Level:
+class Severity:
     DEBUG: Final[Any]
     """
     """
@@ -103,7 +103,7 @@ class Slogger:
     @staticmethod
     def new_file_logger(
         log_path: str,
-        level: "Level",
+        level: "Severity",
         chan_size: int,
         rotate_size: int,
         rotate_keep: int = 1,

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -3,16 +3,13 @@ from typing import Any, Callable, Final, Optional
 
 # TODO: Make these abstract types available in the Python side.
 
-
 class AbstractLogEntry(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
-
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractLogEntry":
         raise NotImplementedError
-
 
 class AbstractStateMachine(metaclass=abc.ABCMeta):
     """
@@ -24,49 +21,38 @@ class AbstractStateMachine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def apply(self, message: bytes) -> bytes:
         raise NotImplementedError
-
     @abc.abstractmethod
     async def snapshot(self) -> bytes:
         raise NotImplementedError
-
     @abc.abstractmethod
     async def restore(self, snapshot: bytes) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
-
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractStateMachine":
         raise NotImplementedError
-
 
 class AbstractLogger(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def info(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def debug(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def trace(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def error(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def warn(self, s: str) -> None:
         raise NotImplementedError
-
     @abc.abstractmethod
     def fatal(self, s: str) -> None:
         raise NotImplementedError
-
 
 class ReadOnlyOption:
     """Determines the relative safety of and consistency of read only requests."""
@@ -86,19 +72,16 @@ class ReadOnlyOption:
     in that case.
     """
 
-
 class Slogger:
     """ """
 
     def __init__(self) -> None: ...
     @staticmethod
     def default() -> "Slogger": ...
-
     @staticmethod
     def new_file_logger(
         level: int, log_path: str, chan_size: int, rotate_size: int, rotate_keep: int
     ): ...
-
 
 class Raft:
     def __init__(self) -> None:
@@ -112,69 +95,49 @@ class Raft:
         logger: "AbstractLogger",
     ) -> "Raft":
         """ """
-
     def get_raft_node(self) -> "RaftNode":
         """ """
     @staticmethod
     async def request_id(raft_addr: str, peer_addr: str) -> "ClusterJoinTicket":
         """"""
-
     async def run(self) -> None:
         """ """
-
 
 class RaftNode:
     async def is_leader(self) -> bool:
         """ """
-
     async def get_id(self) -> int:
         """ """
-
     async def get_leader_id(self) -> int:
         """ """
-
     async def get_peers(self) -> "Peers":
         """ """
-
     async def add_peer(self, id: int, addr: str) -> None:
         """ """
-
     async def inspect(self) -> str:
         """ """
-
     async def propose(self, message: bytes) -> None:
         """ """
-
     async def change_config(self, conf_change: "ConfChangeV2") -> None:
         """ """
-
     async def send_message(self, message: "Message") -> None:
         """ """
-
     async def leave(self) -> None:
         """ """
-
     async def leave_joint(self) -> None:
         """ """
-
     async def demote(self, term: int, leader_id: int) -> None:
         """ """
-
     async def transfer_leader(self, leader_id: int) -> None:
         """ """
-
     async def quit(self) -> None:
         """ """
-
     async def join_cluster(self, tickets: list["ClusterJoinTicket"]) -> None:
         """ """
-
     async def get_cluster_size(self) -> int:
         """ """
-
     async def state_machine(self) -> "AbstractStateMachine":
         """ """
-
 
 class ClusterJoinTicket:
     """ """
@@ -186,16 +149,13 @@ class ClusterJoinTicket:
         leader_addr: str,
         peers: "Peers",
     ) -> None: ...
-
     def get_reserved_id(self) -> int:
         """ """
-
     def to_dict(self) -> dict[str, Any]:
         """ """
     @staticmethod
     def from_dict(v: dict[str, Any]) -> "ClusterJoinTicket":
         """ """
-
 
 class Peer:
     """ """
@@ -205,7 +165,6 @@ class Peer:
     def get_role(self) -> "InitialRole": ...
     async def connect(self) -> None: ...
 
-
 class Peers:
     """ """
 
@@ -214,12 +173,9 @@ class Peers:
     def is_empty(self) -> bool: ...
     def keys(self) -> list[int]: ...
     def get(self, node_id: int) -> "Peer": ...
-    def add_peer(self, node_id: int, addr: str,
-                 role: "InitialRole") -> None: ...
-
+    def add_peer(self, node_id: int, addr: str, role: "InitialRole") -> None: ...
     def remove(self, node_id: int) -> None: ...
     def get_node_id_by_addr(self, addr: str) -> int: ...
-
 
 class RaftConfig:
     """ """
@@ -303,7 +259,6 @@ class RaftConfig:
         :param max_committed_size_per_ready: Max size for committed entries in a `Ready`.
         """
 
-
 class Config:
     """ """
 
@@ -326,11 +281,9 @@ class Config:
     ) -> None:
         """ """
 
-
 class ConfChangeRequest:
     def __init__(self, changes: list["ConfChangeSingle"], addrs: list[str]) -> None:
         """ """
-
 
 class RaftServiceClient:
     """ """
@@ -338,66 +291,50 @@ class RaftServiceClient:
     @staticmethod
     async def build(addr: str) -> "RaftServiceClient":
         """ """
-
     async def change_config(self, conf_change: "ConfChangeRequest") -> None:
         """ """
-
     async def send_message(self, message: "Message") -> None:
         """ """
-
     async def propose(self, proposal: bytes) -> None:
         """ """
-
     async def get_peers(self) -> str:
         """ """
-
     async def set_peers(self, peers: "Peers") -> None:
         """ """
-
     async def leave_joint(self) -> None:
         """ """
-
     async def debug_node(self) -> str:
         """ """
-
 
 def set_snapshot_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
-
 def set_message_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
-
 
 def set_confchange_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
-
 def set_confchangev2_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
-
 def set_entry_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
-
 def set_entry_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
-
 
 def set_fsm_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
 
-
 def set_log_entry_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
-
 
 class ConfChangeTransition:
     """ """
@@ -430,7 +367,6 @@ class ConfChangeTransition:
     def from_int(v: int) -> "ConfChangeTransition": ...
     def __int__(self) -> int: ...
 
-
 class MessageType:
     """ """
 
@@ -457,7 +393,6 @@ class MessageType:
     def from_int(v: int) -> "MessageType": ...
     def __int__(self) -> int: ...
 
-
 class ConfChangeType:
     """ """
 
@@ -468,7 +403,6 @@ class ConfChangeType:
     def from_int(v: int) -> "ConfChangeType": ...
     def __int__(self) -> int: ...
 
-
 class EntryType:
     """ """
 
@@ -478,7 +412,6 @@ class EntryType:
     @staticmethod
     def from_int(v: int) -> "EntryType": ...
     def __int__(self) -> int: ...
-
 
 class InitialRole:
     """ """
@@ -496,52 +429,38 @@ class InitialRole:
     def from_str(v: str) -> "InitialRole": ...
     def __int__(self) -> int: ...
 
-
 class Entry:
     def __init__(self) -> None: ...
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_data(self) -> bytes:
         """ """
-
     def set_data(self, data: bytes) -> None:
         """ """
-
     def get_entry_type(self) -> "EntryType":
         """ """
-
     def set_entry_type(self, type_: "EntryType") -> None:
         """ """
-
     def get_term(self) -> int:
         """ """
-
     def set_term(self, term: int) -> None:
         """ """
-
     def get_index(self) -> int:
         """ """
-
     def set_index(self, index: int) -> None:
         """ """
-
     def get_sync_log(self) -> bool:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
-
     def set_sync_log(self, sync_log: bool) -> None:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
-
 
 class ConfState:
     """ """
@@ -551,135 +470,98 @@ class ConfState:
     ) -> None: ...
     @staticmethod
     def default() -> "ConfState": ...
-
     def get_auto_leave(self) -> bool:
         """ """
-
     def set_auto_leave(self, auto_leave: bool) -> None:
         """ """
-
     def get_learners(self) -> list[int]:
         """ """
-
     def set_learners(self, learners: list[int]) -> None:
         """ """
-
     def get_learners_next(self) -> list[int]:
         """ """
-
     def set_learners_next(self, learners_next: list[int]) -> None:
         """ """
-
     def get_voters(self) -> list[int]:
         """ """
-
     def set_voters(self, voters: list[int]) -> None:
         """ """
-
     def get_voters_outgoing(self) -> list[int]:
         """ """
-
     def set_voters_outgoing(self, voters_outgoing: list[int]) -> None:
         """ """
-
 
 class Snapshot:
     """ """
 
     def __init__(self) -> None: ...
-
     def get_data(self) -> bytes:
         """ """
-
     def set_data(self, data: bytes) -> None:
         """ """
-
     def get_metadata(self) -> "SnapshotMetadata":
         """ """
-
     def set_metadata(self, metadata: "SnapshotMetadata") -> None:
         """ """
-
     def has_metadata(self) -> bool:
         """ """
 
-
 class SnapshotMetadata:
     def __init__(self) -> None: ...
-
     def get_index(self) -> int:
         """
         `index`: The applied index.
         """
-
     def set_index(self, index: int) -> None:
         """
         `index`: The applied index.
         """
-
     def get_term(self) -> int:
         """
         `term`: The term of the applied index.
         """
-
     def set_term(self, term: int) -> None:
         """
         `term`: The term of the applied index.
         """
-
     def get_conf_state(self) -> "ConfState":
         """
         `conf_state`: The current `ConfState`.
         """
-
     def set_conf_state(self, conf_state: "ConfState") -> None:
         """
         `conf_state`: The current `ConfState`.
         """
-
     def has_conf_state(self) -> bool:
         """
         `conf_state`: The current `ConfState`.
         """
 
-
 class ConfChangeSingle:
     def __init__(self) -> None: ...
-
     def get_node_id(self) -> int:
         """ """
-
     def set_node_id(self, node_id: int):
         """ """
-
     def get_change_type(self) -> "ConfChangeType":
         """ """
-
     def set_change_type(self, type_: "ConfChangeType") -> None:
         """ """
 
-
 class ConfChangeV2:
     def __init__(self) -> None: ...
-
     def get_changes(self) -> list["ConfChangeSingle"]:
         """ """
-
     def set_changes(self, changes: list["ConfChangeSingle"]) -> None:
         """ """
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_transition(self) -> "ConfChangeTransition":
         """ """
-
     def set_transition(self, transition: "ConfChangeTransition") -> None:
         """ """
-
     def enter_joint(self) -> Optional[bool]:
         """
         Checks if uses Joint Consensus.
@@ -689,7 +571,6 @@ class ConfChangeV2:
         Consensus was requested explicitly. The bool indicates whether the Joint State
         will be left automatically.
         """
-
     def leave_joint(self) -> bool:
         """
         Checks if the configuration change leaves a joint configuration.
@@ -698,109 +579,74 @@ class ConfChangeV2:
         the Context field.
         """
 
-
 class Message:
     def __init__(self) -> None: ...
-
     def get_commit(self) -> int:
         """ """
-
     def set_commit(self, commit: int) -> None:
         """ """
-
     def get_commit_term(self) -> int:
         """ """
-
     def set_commit_term(self, commit_term: int) -> None:
         """ """
-
     def get_from(self) -> int:
         """ """
-
     def set_from(self, from_: int) -> None:
         """ """
-
     def get_index(self) -> int:
         """ """
-
     def set_index(self, index: int) -> None:
         """ """
-
     def get_term(self) -> int:
         """ """
-
     def set_term(self, term: int) -> None:
         """ """
-
     def get_log_term(self) -> int:
         """ """
-
     def set_log_term(self, log_index: int) -> None:
         """ """
-
     def get_priority(self) -> int:
         """ """
-
     def set_priority(self, priority: int) -> None:
         """ """
-
     def get_context(self) -> bytes:
         """ """
-
     def set_context(self, context: bytes) -> None:
         """ """
-
     def get_reject_hint(self) -> int:
         """ """
-
     def set_reject_hint(self, reject_hint: int) -> None:
         """ """
-
     def get_entries(self) -> list["Entry"]:
         """ """
-
     def set_entries(self, entries: list["Entry"]) -> None:
         """ """
-
     def get_msg_type(self) -> "MessageType":
         """ """
-
     def set_msg_type(self, type_: "MessageType") -> None:
         """ """
-
     def get_reject(self) -> bool:
         """ """
-
     def set_reject(self, reject: bool) -> None:
         """ """
-
     def get_snapshot(self) -> "Snapshot":
         """ """
-
     def set_snapshot(self, snapshot: "Snapshot") -> None:
         """ """
-
     def get_to(self) -> int:
         """ """
-
     def set_to(self, to: int) -> None:
         """ """
-
     def get_request_snapshot(self) -> int:
         """ """
-
     def set_request_snapshot(self, request_snapshot: int) -> None:
         """ """
-
     def has_snapshot(self) -> bool:
         """ """
-
     def get_deprecated_priority(self) -> int:
         """ """
-
     def set_deprecated_priority(self, deprecated_priority: int) -> None:
         """ """
-
 
 async def cli_main(argv: list[str]) -> None:
     """ """

--- a/binding/python/raftify.pyi
+++ b/binding/python/raftify.pyi
@@ -3,13 +3,16 @@ from typing import Any, Callable, Final, Optional
 
 # TODO: Make these abstract types available in the Python side.
 
+
 class AbstractLogEntry(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
+
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractLogEntry":
         raise NotImplementedError
+
 
 class AbstractStateMachine(metaclass=abc.ABCMeta):
     """
@@ -21,38 +24,49 @@ class AbstractStateMachine(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     async def apply(self, message: bytes) -> bytes:
         raise NotImplementedError
+
     @abc.abstractmethod
     async def snapshot(self) -> bytes:
         raise NotImplementedError
+
     @abc.abstractmethod
     async def restore(self, snapshot: bytes) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def encode(self) -> bytes:
         raise NotImplementedError
+
     @classmethod
     def decode(cls, packed: bytes) -> "AbstractStateMachine":
         raise NotImplementedError
+
 
 class AbstractLogger(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def info(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def debug(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def trace(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def error(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def warn(self, s: str) -> None:
         raise NotImplementedError
+
     @abc.abstractmethod
     def fatal(self, s: str) -> None:
         raise NotImplementedError
+
 
 class ReadOnlyOption:
     """Determines the relative safety of and consistency of read only requests."""
@@ -72,33 +86,29 @@ class ReadOnlyOption:
     in that case.
     """
 
+
 class Level:
     DEBUG: Final[Any]
     """
-    Detailed information, typically only of interest to a developer trying to diagnose a problem.
     """
 
     INFO: Final[Any]
     """
-    Confirmation that things are working as expected.
     """
 
     WARNING: Final[Any]
     """ 
-    An indication that something unexpected happened, or that a problem might occur in the near future (e.g. ‘disk space low’). 
-    The software is still working as expected. 
     """
 
     ERROR: Final[Any]
     """ 
-    Due to a more serious problem, the software has not been able to perform some function.
     """
 
     CRITICAL: Final[Any]
 
     """ 
-    A serious error, indicating that the program itself may be unable to continue running.
     """
+
 
 class Slogger:
     """ """
@@ -106,14 +116,16 @@ class Slogger:
     def __init__(self) -> None: ...
     @staticmethod
     def default() -> "Slogger": ...
+
     @staticmethod
     def new_file_logger(
         log_path: str,
-        level: "Level" = Level.DEBUG,
-        chan_size: int = 3000,
-        rotate_size: int = 1024 * 1024 * 10,
+        level: "Level",
+        chan_size: int,
+        rotate_size: int,
         rotate_keep: int = 1,
     ): ...
+
 
 class Raft:
     def __init__(self) -> None:
@@ -127,49 +139,69 @@ class Raft:
         logger: "AbstractLogger",
     ) -> "Raft":
         """ """
+
     def get_raft_node(self) -> "RaftNode":
         """ """
     @staticmethod
     async def request_id(raft_addr: str, peer_addr: str) -> "ClusterJoinTicket":
         """"""
+
     async def run(self) -> None:
         """ """
+
 
 class RaftNode:
     async def is_leader(self) -> bool:
         """ """
+
     async def get_id(self) -> int:
         """ """
+
     async def get_leader_id(self) -> int:
         """ """
+
     async def get_peers(self) -> "Peers":
         """ """
+
     async def add_peer(self, id: int, addr: str) -> None:
         """ """
+
     async def inspect(self) -> str:
         """ """
+
     async def propose(self, message: bytes) -> None:
         """ """
+
     async def change_config(self, conf_change: "ConfChangeV2") -> None:
         """ """
+
     async def send_message(self, message: "Message") -> None:
         """ """
+
     async def leave(self) -> None:
         """ """
+
     async def leave_joint(self) -> None:
         """ """
+
     async def demote(self, term: int, leader_id: int) -> None:
         """ """
+
     async def transfer_leader(self, leader_id: int) -> None:
         """ """
+
     async def quit(self) -> None:
         """ """
+
     async def join_cluster(self, tickets: list["ClusterJoinTicket"]) -> None:
         """ """
+
     async def get_cluster_size(self) -> int:
         """ """
+
     async def state_machine(self) -> "AbstractStateMachine":
         """ """
+
 
 class ClusterJoinTicket:
     """ """
@@ -181,13 +213,16 @@ class ClusterJoinTicket:
         leader_addr: str,
         peers: "Peers",
     ) -> None: ...
+
     def get_reserved_id(self) -> int:
         """ """
+
     def to_dict(self) -> dict[str, Any]:
         """ """
     @staticmethod
     def from_dict(v: dict[str, Any]) -> "ClusterJoinTicket":
         """ """
+
 
 class Peer:
     """ """
@@ -197,6 +232,7 @@ class Peer:
     def get_role(self) -> "InitialRole": ...
     async def connect(self) -> None: ...
 
+
 class Peers:
     """ """
 
@@ -205,9 +241,12 @@ class Peers:
     def is_empty(self) -> bool: ...
     def keys(self) -> list[int]: ...
     def get(self, node_id: int) -> "Peer": ...
-    def add_peer(self, node_id: int, addr: str, role: "InitialRole") -> None: ...
+    def add_peer(self, node_id: int, addr: str,
+                 role: "InitialRole") -> None: ...
+
     def remove(self, node_id: int) -> None: ...
     def get_node_id_by_addr(self, addr: str) -> int: ...
+
 
 class RaftConfig:
     """ """
@@ -291,6 +330,7 @@ class RaftConfig:
         :param max_committed_size_per_ready: Max size for committed entries in a `Ready`.
         """
 
+
 class Config:
     """ """
 
@@ -313,9 +353,11 @@ class Config:
     ) -> None:
         """ """
 
+
 class ConfChangeRequest:
     def __init__(self, changes: list["ConfChangeSingle"], addrs: list[str]) -> None:
         """ """
+
 
 class RaftServiceClient:
     """ """
@@ -323,50 +365,66 @@ class RaftServiceClient:
     @staticmethod
     async def build(addr: str) -> "RaftServiceClient":
         """ """
+
     async def change_config(self, conf_change: "ConfChangeRequest") -> None:
         """ """
+
     async def send_message(self, message: "Message") -> None:
         """ """
+
     async def propose(self, proposal: bytes) -> None:
         """ """
+
     async def get_peers(self) -> str:
         """ """
+
     async def set_peers(self, peers: "Peers") -> None:
         """ """
+
     async def leave_joint(self) -> None:
         """ """
+
     async def debug_node(self) -> str:
         """ """
+
 
 def set_snapshot_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
+
 def set_message_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
+
 
 def set_confchange_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
+
 def set_confchangev2_context_deserializer(
     cb: Callable[[bytes], str | bytes | None]
 ) -> None:
     """ """
 
+
 def set_entry_data_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
 
+
 def set_entry_context_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
+
 
 def set_fsm_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
 
+
 def set_log_entry_deserializer(cb: Callable[[bytes], str | bytes | None]) -> None:
     """ """
     ...
+
 
 class ConfChangeTransition:
     """ """
@@ -399,6 +457,7 @@ class ConfChangeTransition:
     def from_int(v: int) -> "ConfChangeTransition": ...
     def __int__(self) -> int: ...
 
+
 class MessageType:
     """ """
 
@@ -425,6 +484,7 @@ class MessageType:
     def from_int(v: int) -> "MessageType": ...
     def __int__(self) -> int: ...
 
+
 class ConfChangeType:
     """ """
 
@@ -435,6 +495,7 @@ class ConfChangeType:
     def from_int(v: int) -> "ConfChangeType": ...
     def __int__(self) -> int: ...
 
+
 class EntryType:
     """ """
 
@@ -444,6 +505,7 @@ class EntryType:
     @staticmethod
     def from_int(v: int) -> "EntryType": ...
     def __int__(self) -> int: ...
+
 
 class InitialRole:
     """ """
@@ -461,38 +523,52 @@ class InitialRole:
     def from_str(v: str) -> "InitialRole": ...
     def __int__(self) -> int: ...
 
+
 class Entry:
     def __init__(self) -> None: ...
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_data(self) -> bytes:
         """ """
+
     def set_data(self, data: bytes) -> None:
         """ """
+
     def get_entry_type(self) -> "EntryType":
         """ """
+
     def set_entry_type(self, type_: "EntryType") -> None:
         """ """
+
     def get_term(self) -> int:
         """ """
+
     def set_term(self, term: int) -> None:
         """ """
+
     def get_index(self) -> int:
         """ """
+
     def set_index(self, index: int) -> None:
         """ """
+
     def get_sync_log(self) -> bool:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
+
     def set_sync_log(self, sync_log: bool) -> None:
         """
         Deprecated! It is kept for backward compatibility.
         TODO: remove it in the next major release.
         """
+
 
 class ConfState:
     """ """
@@ -502,98 +578,135 @@ class ConfState:
     ) -> None: ...
     @staticmethod
     def default() -> "ConfState": ...
+
     def get_auto_leave(self) -> bool:
         """ """
+
     def set_auto_leave(self, auto_leave: bool) -> None:
         """ """
+
     def get_learners(self) -> list[int]:
         """ """
+
     def set_learners(self, learners: list[int]) -> None:
         """ """
+
     def get_learners_next(self) -> list[int]:
         """ """
+
     def set_learners_next(self, learners_next: list[int]) -> None:
         """ """
+
     def get_voters(self) -> list[int]:
         """ """
+
     def set_voters(self, voters: list[int]) -> None:
         """ """
+
     def get_voters_outgoing(self) -> list[int]:
         """ """
+
     def set_voters_outgoing(self, voters_outgoing: list[int]) -> None:
         """ """
+
 
 class Snapshot:
     """ """
 
     def __init__(self) -> None: ...
+
     def get_data(self) -> bytes:
         """ """
+
     def set_data(self, data: bytes) -> None:
         """ """
+
     def get_metadata(self) -> "SnapshotMetadata":
         """ """
+
     def set_metadata(self, metadata: "SnapshotMetadata") -> None:
         """ """
+
     def has_metadata(self) -> bool:
         """ """
 
+
 class SnapshotMetadata:
     def __init__(self) -> None: ...
+
     def get_index(self) -> int:
         """
         `index`: The applied index.
         """
+
     def set_index(self, index: int) -> None:
         """
         `index`: The applied index.
         """
+
     def get_term(self) -> int:
         """
         `term`: The term of the applied index.
         """
+
     def set_term(self, term: int) -> None:
         """
         `term`: The term of the applied index.
         """
+
     def get_conf_state(self) -> "ConfState":
         """
         `conf_state`: The current `ConfState`.
         """
+
     def set_conf_state(self, conf_state: "ConfState") -> None:
         """
         `conf_state`: The current `ConfState`.
         """
+
     def has_conf_state(self) -> bool:
         """
         `conf_state`: The current `ConfState`.
         """
 
+
 class ConfChangeSingle:
     def __init__(self) -> None: ...
+
     def get_node_id(self) -> int:
         """ """
+
     def set_node_id(self, node_id: int):
         """ """
+
     def get_change_type(self) -> "ConfChangeType":
         """ """
+
     def set_change_type(self, type_: "ConfChangeType") -> None:
         """ """
 
+
 class ConfChangeV2:
     def __init__(self) -> None: ...
+
     def get_changes(self) -> list["ConfChangeSingle"]:
         """ """
+
     def set_changes(self, changes: list["ConfChangeSingle"]) -> None:
         """ """
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_transition(self) -> "ConfChangeTransition":
         """ """
+
     def set_transition(self, transition: "ConfChangeTransition") -> None:
         """ """
+
     def enter_joint(self) -> Optional[bool]:
         """
         Checks if uses Joint Consensus.
@@ -603,6 +716,7 @@ class ConfChangeV2:
         Consensus was requested explicitly. The bool indicates whether the Joint State
         will be left automatically.
         """
+
     def leave_joint(self) -> bool:
         """
         Checks if the configuration change leaves a joint configuration.
@@ -611,74 +725,109 @@ class ConfChangeV2:
         the Context field.
         """
 
+
 class Message:
     def __init__(self) -> None: ...
+
     def get_commit(self) -> int:
         """ """
+
     def set_commit(self, commit: int) -> None:
         """ """
+
     def get_commit_term(self) -> int:
         """ """
+
     def set_commit_term(self, commit_term: int) -> None:
         """ """
+
     def get_from(self) -> int:
         """ """
+
     def set_from(self, from_: int) -> None:
         """ """
+
     def get_index(self) -> int:
         """ """
+
     def set_index(self, index: int) -> None:
         """ """
+
     def get_term(self) -> int:
         """ """
+
     def set_term(self, term: int) -> None:
         """ """
+
     def get_log_term(self) -> int:
         """ """
+
     def set_log_term(self, log_index: int) -> None:
         """ """
+
     def get_priority(self) -> int:
         """ """
+
     def set_priority(self, priority: int) -> None:
         """ """
+
     def get_context(self) -> bytes:
         """ """
+
     def set_context(self, context: bytes) -> None:
         """ """
+
     def get_reject_hint(self) -> int:
         """ """
+
     def set_reject_hint(self, reject_hint: int) -> None:
         """ """
+
     def get_entries(self) -> list["Entry"]:
         """ """
+
     def set_entries(self, entries: list["Entry"]) -> None:
         """ """
+
     def get_msg_type(self) -> "MessageType":
         """ """
+
     def set_msg_type(self, type_: "MessageType") -> None:
         """ """
+
     def get_reject(self) -> bool:
         """ """
+
     def set_reject(self, reject: bool) -> None:
         """ """
+
     def get_snapshot(self) -> "Snapshot":
         """ """
+
     def set_snapshot(self, snapshot: "Snapshot") -> None:
         """ """
+
     def get_to(self) -> int:
         """ """
+
     def set_to(self, to: int) -> None:
         """ """
+
     def get_request_snapshot(self) -> int:
         """ """
+
     def set_request_snapshot(self, request_snapshot: int) -> None:
         """ """
+
     def has_snapshot(self) -> bool:
         """ """
+
     def get_deprecated_priority(self) -> int:
         """ """
+
     def set_deprecated_priority(self, deprecated_priority: int) -> None:
         """ """
+
 
 async def cli_main(argv: list[str]) -> None:
     """ """

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -10,7 +10,7 @@ use sloggers::{
 
 #[pyclass(name = "Level")]
 #[derive(Clone, Copy, Debug)]
-pub enum PyLevel {
+pub enum PySeverity {
     TRACE,
     DEBUG,
     INFO,
@@ -19,15 +19,15 @@ pub enum PyLevel {
     CRITICAL,
 }
 
-impl From<PyLevel> for Severity {
-    fn from(py_severity: PyLevel) -> Self {
+impl From<PySeverity> for Severity {
+    fn from(py_severity: PySeverity) -> Self {
         match py_severity {
-            PyLevel::TRACE => Severity::Trace,
-            PyLevel::DEBUG => Severity::Debug,
-            PyLevel::INFO => Severity::Info,
-            PyLevel::WARNING => Severity::Warning,
-            PyLevel::ERROR => Severity::Error,
-            PyLevel::CRITICAL => Severity::Critical,
+            PySeverity::TRACE => Severity::Trace,
+            PySeverity::DEBUG => Severity::Debug,
+            PySeverity::INFO => Severity::Info,
+            PySeverity::WARNING => Severity::Warning,
+            PySeverity::ERROR => Severity::Error,
+            PySeverity::CRITICAL => Severity::Critical,
         }
     }
 }
@@ -128,14 +128,14 @@ impl PySlogger {
     #[staticmethod]
     #[pyo3(signature = (
         log_path,
-        level = PyLevel::DEBUG,        
-        chan_size = 3000,               
-        rotate_size = 1024 * 1024 * 10, 
-        rotate_keep = 1                 
+        level,        
+        chan_size,               
+        rotate_size, 
+        rotate_keep = 1
     ))]
     pub fn new_file_logger(
         log_path: &PyString,
-        level: PyLevel,
+        level: PySeverity,
         chan_size: usize,
         rotate_size: u64,
         rotate_keep: usize,

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -126,9 +126,16 @@ impl PySlogger {
     }
 
     #[staticmethod]
+    #[pyo3(signature = (
+        log_path,
+        level = PyLevel::DEBUG,        
+        chan_size = 3000,               
+        rotate_size = 1024 * 1024 * 10, 
+        rotate_keep = 1                 
+    ))]
     pub fn new_file_logger(
-        level: PyLevel,
         log_path: &PyString,
+        level: PyLevel,
         chan_size: usize,
         rotate_size: u64,
         rotate_keep: usize,

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -8,7 +8,7 @@ use sloggers::{
     Build,
 };
 
-#[pyclass(name = "Level")]
+#[pyclass(name = "Severity")]
 #[derive(Clone, Copy, Debug)]
 pub enum PySeverity {
     TRACE,

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -8,6 +8,30 @@ use sloggers::{
     Build,
 };
 
+#[pyclass(name = "Level")]
+#[derive(Clone, Copy, Debug)]
+pub enum PyLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    CRITICAL,
+}
+
+impl From<PyLevel> for Severity {
+    fn from(py_severity: PyLevel) -> Self {
+        match py_severity {
+            PyLevel::TRACE => Severity::Trace,
+            PyLevel::DEBUG => Severity::Debug,
+            PyLevel::INFO => Severity::Info,
+            PyLevel::WARNING => Severity::Warning,
+            PyLevel::ERROR => Severity::Error,
+            PyLevel::CRITICAL => Severity::Critical,
+        }
+    }
+}
+
 #[pyclass(name = "OverflowStrategy")]
 pub struct PyOverflowStrategy(pub OverflowStrategy);
 
@@ -103,6 +127,7 @@ impl PySlogger {
 
     #[staticmethod]
     pub fn new_file_logger(
+        level: PyLevel,
         log_path: &PyString,
         chan_size: usize,
         rotate_size: u64,
@@ -111,8 +136,7 @@ impl PySlogger {
         let log_path = log_path.to_str().unwrap();
 
         let logger = FileLoggerBuilder::new(log_path)
-            // TODO: Implement this
-            .level(Severity::Debug)
+            .level(level.into())
             .source_location(SourceLocation::LocalFileAndLine)
             .channel_size(chan_size)
             .rotate_size(rotate_size)

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -20,8 +20,8 @@ pub enum PySeverity {
 }
 
 impl From<PySeverity> for Severity {
-    fn from(py_severity: PySeverity) -> Self {
-        match py_severity {
+    fn from(severity: PySeverity) -> Self {
+        match severity {
             PySeverity::TRACE => Severity::Trace,
             PySeverity::DEBUG => Severity::Debug,
             PySeverity::INFO => Severity::Info,
@@ -126,13 +126,6 @@ impl PySlogger {
     }
 
     #[staticmethod]
-    #[pyo3(signature = (
-        log_path,
-        level,        
-        chan_size,               
-        rotate_size, 
-        rotate_keep = 1
-    ))]
     pub fn new_file_logger(
         log_path: &PyString,
         level: PySeverity,

--- a/binding/python/src/lib.rs
+++ b/binding/python/src/lib.rs
@@ -11,6 +11,7 @@ fn raftify(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<bindings::confchange_request::PyConfChangeRequest>()?;
     m.add_class::<bindings::config::PyConfig>()?;
     m.add_class::<bindings::slogger::PySlogger>()?;
+    m.add_class::<bindings::slogger::PyLevel>()?;
     m.add_class::<bindings::slogger::PyOverflowStrategy>()?;
     m.add_class::<bindings::peers::PyPeers>()?;
     m.add_class::<bindings::peer::PyPeer>()?;

--- a/binding/python/src/lib.rs
+++ b/binding/python/src/lib.rs
@@ -11,7 +11,7 @@ fn raftify(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<bindings::confchange_request::PyConfChangeRequest>()?;
     m.add_class::<bindings::config::PyConfig>()?;
     m.add_class::<bindings::slogger::PySlogger>()?;
-    m.add_class::<bindings::slogger::PyLevel>()?;
+    m.add_class::<bindings::slogger::PySeverity>()?;
     m.add_class::<bindings::slogger::PyOverflowStrategy>()?;
     m.add_class::<bindings::peers::PyPeers>()?;
     m.add_class::<bindings::peer::PyPeer>()?;


### PR DESCRIPTION
# Changes
1. Added a new PyLevel enum to represent different logging levels (TRACE, DEBUG, INFO, WARNING, ERROR, CRITICAL). This allows users to specify the logging severity level when creating a new file logger.
2. Updated the Slogger.new_file_logger method to accept a level argument, enabling users to dynamically set the logging level from Python.
3. Registered the PyLevel class in the Python bindings, making it available for use within Python code.