### PR TITLE
feat: Add pre-commit hooks for code formatting, linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        name: Running "cargo fmt"
+        description: Format files with cargo fmt.
+      - id: clippy
+        name: Running "cargo clippy"
+        description: Lint rust sources
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.7
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,3 +5,21 @@ You can use this command to clone the repository:
 ```
 ❯ git clone --recursive https://github.com/lablup/raftify.git
 ```
+
+If you already cloned it and forgot to initialize the submodules, execute the following command:
+
+```
+❯ git submodule update --init
+```
+
+# Development environment setup
+
+## precommit hook setup
+
+You can use pre-commit hooks with the following configuration.
+This commit hook performs checks like cargo fmt and cargo clippy before committing.
+
+```
+❯ pip install pre-commit --break-system-packages
+❯ pre-commit install
+```

--- a/raftify/src/raft_node/mod.rs
+++ b/raftify/src/raft_node/mod.rs
@@ -1147,6 +1147,7 @@ impl<
                 tx_msg
                     .send(LocalResponseMsg::GetRawNode {
                         raw_node: Arc::new(Mutex::new(unsafe {
+                            #[allow(clippy::missing_transmute_annotations)]
                             std::mem::transmute(&self.raw_node)
                         })),
                     })


### PR DESCRIPTION
This PR introduces pre-commit hooks to ensure consistent code quality and formatting across the project. The following hooks were added:

1. **Rust Hooks**:
   - `cargo fmt`: Automatically formats Rust code according to the standard style.
   - `cargo clippy`: Lints Rust code to detect potential issues and improve code quality.

2. **General Code Quality Hooks**:
   - `trailing-whitespace`: Removes unnecessary trailing whitespace from files.
   - `end-of-file-fixer`: Ensures that files end with a newline.
   - `check-yaml`: Validates YAML file syntax.
   - `check-added-large-files`: Prevents large files from being accidentally committed to the repository.

3. **Python Hooks**:
   - `ruff`: Lints Python code and automatically fixes style issues.