### PR TITLE
feat: Support TLS config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2135,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,6 +2194,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2241,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -2360,6 +2438,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -2598,6 +2682,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2764,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
@@ -2684,7 +2779,9 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -2819,6 +2916,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "example-harness"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "raftify",
 ]
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1549,7 +1549,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memstore-dynamic-members"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1573,7 +1573,7 @@ dependencies = [
 
 [[package]]
 name = "memstore-example-harness"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "memstore-static-members"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "raftify"
-version = "0.1.78"
+version = "0.1.80"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2035,14 +2035,15 @@ dependencies = [
 
 [[package]]
 name = "raftify_cli"
-version = "0.1.1"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89fca418beb04ff1d175598c386db1d8bc40b20b0f2a1e645fe9d5bb0789a7d6"
+checksum = "d90e7b2a6ada58910273956addaad5100d76a3e888f55e3831d3d20bd8f3cb40"
 dependencies = [
  "built",
  "clap 4.5.18",
  "log",
  "raftify",
+ "rocksdb",
  "serde",
  "serde_json",
  "slog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 exclude = ["raft-rs", "raftify-cli"]
 
 [workspace.package]
-version = "0.1.78"
+version = "0.1.80"
 authors = ["Lablup Inc."]
 edition = "2021"
 description = "Experimental High level Raft framework"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,5 +12,5 @@ keywords.workspace = true
 raftify.workspace = true
 
 [features]
-default = ["tls"]
+default = []
 tls = []

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,3 +10,7 @@ keywords.workspace = true
 
 [dependencies]
 raftify.workspace = true
+
+[features]
+default = ["tls"]
+tls = []

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -30,7 +30,7 @@ raftify = { version = "0.1.80" }
 raftify_cli = { version = "0.1.80" }
 
 [features]
-default = ["heed_storage", "tls"]
+default = ["heed_storage"]
 inmemory_storage = []
 heed_storage = []
 rocksdb_storage = []

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -26,11 +26,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["full"] }
 color-backtrace = "0.6.1"
-raftify = { version = "0.1.78" }
-raftify_cli = { version = "0.1.1" }
+raftify = { version = "0.1.80" }
+raftify_cli = { version = "0.1.80" }
 
 [features]
-default = ["heed_storage"]
+default = ["heed_storage", "tls"]
 inmemory_storage = []
 heed_storage = []
 rocksdb_storage = []
+tls = []

--- a/examples/memstore/dynamic-members/src/main.rs
+++ b/examples/memstore/dynamic-members/src/main.rs
@@ -70,19 +70,17 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         Some(peer_addr) => {
             log::info!("Running in Follower mode");
 
-            let ticket = Raft::request_id(options.raft_addr.clone(), peer_addr.clone())
+            let ticket = Raft::request_id(options.raft_addr.clone(), peer_addr.clone(), None)
                 .await
                 .unwrap();
             let node_id = ticket.reserved_id;
-            let mut cfg = build_config(node_id);
-
-            cfg.initial_peers = Some(ticket.peers.clone().into());
+            let cfg = build_config(node_id, Some(ticket.peers.clone().into()));
 
             #[cfg(feature = "inmemory_storage")]
             let log_storage = MemStorage::create();
 
             #[cfg(feature = "heed_storage")]
-            let log_storage = HeedStorage::create(&cfg.log_dir, &cfg.clone(), logger.clone())
+            let log_storage = HeedStorage::create(cfg.get_log_dir(), &cfg.clone(), logger.clone())
                 .expect("Failed to create storage");
 
             #[cfg(feature = "rocksdb_storage")]
@@ -121,13 +119,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             }
 
             let leader_node_id = 1;
-            let cfg = build_config(leader_node_id);
+            let cfg = build_config(leader_node_id, None);
 
             #[cfg(feature = "inmemory_storage")]
             let log_storage = MemStorage::create();
 
             #[cfg(feature = "heed_storage")]
-            let log_storage = HeedStorage::create(&cfg.log_dir, &cfg.clone(), logger.clone())
+            let log_storage = HeedStorage::create(cfg.get_log_dir(), &cfg.clone(), logger.clone())
                 .expect("Failed to create storage");
 
             #[cfg(feature = "rocksdb_storage")]

--- a/examples/memstore/src/client/main.rs
+++ b/examples/memstore/src/client/main.rs
@@ -7,7 +7,7 @@ use memstore_example_harness::state_machine::LogEntry;
 #[actix_rt::main]
 async fn main() {
     println!("---Message propose---");
-    let mut leader_client = create_client(&"127.0.0.1:60061").await.unwrap();
+    let mut leader_client = create_client(&"127.0.0.1:60061", None).await.unwrap();
 
     leader_client
         .propose(raft_service::ProposeArgs {

--- a/examples/memstore/static-members/Cargo.toml
+++ b/examples/memstore/static-members/Cargo.toml
@@ -33,4 +33,3 @@ default = ["heed_storage"]
 inmemory_storage = []
 heed_storage = []
 rocksdb_storage = []
-

--- a/examples/memstore/static-members/src/main.rs
+++ b/examples/memstore/static-members/src/main.rs
@@ -71,14 +71,13 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .get_node_id_by_addr(options.raft_addr.clone())
         .unwrap();
 
-    let mut cfg = build_config(node_id);
-    cfg.initial_peers = Some(initial_peers.clone());
+    let cfg = build_config(node_id, Some(initial_peers.clone()));
 
     #[cfg(feature = "inmemory_storage")]
     let log_storage = MemStorage::create();
 
     #[cfg(feature = "heed_storage")]
-    let log_storage = HeedStorage::create(&cfg.log_dir, &cfg.clone(), logger.clone())
+    let log_storage = HeedStorage::create(cfg.get_log_dir(), &cfg.clone(), logger.clone())
         .expect("Failed to create storage");
 
     #[cfg(feature = "rocksdb_storage")]

--- a/examples/src/config.rs
+++ b/examples/src/config.rs
@@ -17,6 +17,7 @@ pub fn build_config(node_id: u64, initial_peers: Option<Peers>) -> Config {
     let storage_pth = get_storage_path("./logs", node_id);
     ensure_directory_exist(&storage_pth).expect("Failed to create storage directory");
 
+    #[allow(unused_mut)]
     let mut config_builder = ConfigBuilder::new()
         .log_dir("./logs".to_owned())
         .save_compacted_logs(true)

--- a/examples/src/config.rs
+++ b/examples/src/config.rs
@@ -1,8 +1,8 @@
-use raftify::{Config, RaftConfig};
+use raftify::{Config, ConfigBuilder, Peers, RaftConfig, TlsConfig};
 
 use crate::utils::{ensure_directory_exist, get_storage_path};
 
-pub fn build_config(node_id: u64) -> Config {
+pub fn build_config(node_id: u64, initial_peers: Option<Peers>) -> Config {
     let raft_config = RaftConfig {
         id: node_id,
         election_tick: 10,
@@ -14,14 +14,27 @@ pub fn build_config(node_id: u64) -> Config {
     let storage_pth = get_storage_path("./logs", node_id);
     ensure_directory_exist(&storage_pth).expect("Failed to create storage directory");
 
-    Config {
-        bootstrap_from_snapshot: false,
-        tick_interval: 0.2,
-        log_dir: storage_pth.clone(),
-        save_compacted_logs: true,
-        compacted_log_dir: storage_pth,
-        compacted_log_size_threshold: 1024 * 1024 * 1024,
-        raft_config,
-        ..Default::default()
-    }
+    let client_tls_config = TlsConfig {
+        cert_path: None,
+        key_path: None,
+        ca_cert_path: Some("./ca_cert.pem".to_string()),
+        domain_name: Some("localhost".to_string()),
+    };
+
+    let config_builder = ConfigBuilder::new()
+        .log_dir("./logs".to_owned())
+        .save_compacted_logs(true)
+        .compacted_log_dir("./logs".to_owned())
+        .compacted_log_size_threshold(1024 * 1024 * 1024)
+        .raft_config(raft_config)
+        .tick_interval(0.2)
+        .global_client_tls_config(client_tls_config);
+
+    let config_builder = if let Some(peers) = initial_peers {
+        config_builder.initial_peers(peers)
+    } else {
+        config_builder
+    };
+
+    config_builder.build()
 }

--- a/examples/src/config.rs
+++ b/examples/src/config.rs
@@ -1,4 +1,7 @@
-use raftify::{Config, ConfigBuilder, Peers, RaftConfig, TlsConfig};
+use raftify::{Config, ConfigBuilder, Peers, RaftConfig};
+
+#[cfg(feature = "tls")]
+use raftify::TlsConfig;
 
 use crate::utils::{ensure_directory_exist, get_storage_path};
 
@@ -14,21 +17,25 @@ pub fn build_config(node_id: u64, initial_peers: Option<Peers>) -> Config {
     let storage_pth = get_storage_path("./logs", node_id);
     ensure_directory_exist(&storage_pth).expect("Failed to create storage directory");
 
-    let client_tls_config = TlsConfig {
-        cert_path: None,
-        key_path: None,
-        ca_cert_path: Some("./ca_cert.pem".to_string()),
-        domain_name: Some("localhost".to_string()),
-    };
-
-    let config_builder = ConfigBuilder::new()
+    let mut config_builder = ConfigBuilder::new()
         .log_dir("./logs".to_owned())
         .save_compacted_logs(true)
         .compacted_log_dir("./logs".to_owned())
         .compacted_log_size_threshold(1024 * 1024 * 1024)
         .raft_config(raft_config)
-        .tick_interval(0.2)
-        .global_client_tls_config(client_tls_config);
+        .tick_interval(0.2);
+
+    #[cfg(feature = "tls")]
+    {
+        let client_tls_config = TlsConfig {
+            cert_path: None,
+            key_path: None,
+            ca_cert_path: Some("./ca_cert.pem".to_string()),
+            domain_name: Some("localhost".to_string()),
+        };
+
+        config_builder = config_builder.global_client_tls_config(client_tls_config);
+    }
 
     let config_builder = if let Some(peers) = initial_peers {
         config_builder.initial_peers(peers)

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -15,12 +15,11 @@ pub fn build_config(node_id: u64, initial_peers: Option<Peers>) -> Config {
     ensure_directory_exist(&storage_path).expect("Failed to create storage directory");
 
     let config_builder = ConfigBuilder::new()
-        .log_dir("./logs".to_owned())
+        .log_dir(storage_path.clone())
         .save_compacted_logs(true)
-        .compacted_log_dir("./logs".to_owned())
+        .compacted_log_dir(storage_path)
         .compacted_log_size_threshold(1024 * 1024 * 1024)
-        .raft_config(raft_config)
-        .tick_interval(0.2);
+        .raft_config(raft_config);
 
     let config_builder = if let Some(peers) = initial_peers {
         config_builder.initial_peers(peers)

--- a/harness/src/config.rs
+++ b/harness/src/config.rs
@@ -1,8 +1,8 @@
-use raftify::{Config, RaftConfig};
+use raftify::{Config, ConfigBuilder, Peers, RaftConfig};
 
 use crate::utils::{ensure_directory_exist, get_storage_path};
 
-pub fn build_config(node_id: u64) -> Config {
+pub fn build_config(node_id: u64, initial_peers: Option<Peers>) -> Config {
     let raft_config = RaftConfig {
         id: node_id,
         election_tick: 10,
@@ -14,12 +14,19 @@ pub fn build_config(node_id: u64) -> Config {
     let storage_path = get_storage_path("./logs", node_id);
     ensure_directory_exist(&storage_path).expect("Failed to create storage directory");
 
-    Config {
-        log_dir: storage_path.clone(),
-        save_compacted_logs: true,
-        compacted_log_dir: storage_path,
-        compacted_log_size_threshold: 1024 * 1024 * 1024,
-        raft_config,
-        ..Default::default()
-    }
+    let config_builder = ConfigBuilder::new()
+        .log_dir("./logs".to_owned())
+        .save_compacted_logs(true)
+        .compacted_log_dir("./logs".to_owned())
+        .compacted_log_size_threshold(1024 * 1024 * 1024)
+        .raft_config(raft_config)
+        .tick_interval(0.2);
+
+    let config_builder = if let Some(peers) = initial_peers {
+        config_builder.initial_peers(peers)
+    } else {
+        config_builder
+    };
+
+    config_builder.build()
 }

--- a/raftify-cli/Cargo.lock
+++ b/raftify-cli/Cargo.lock
@@ -103,6 +103,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +217,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +279,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +307,18 @@ version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -275,6 +339,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-targets",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -517,6 +592,12 @@ name = "gimli"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -776,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "jopemachine-raft"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,10 +901,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
 
 [[package]]
 name = "libredox"
@@ -824,6 +930,32 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.8.3+7.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -878,6 +1010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +1041,16 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-conv"
@@ -966,6 +1114,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1056,6 +1210,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "powerfmt"
@@ -1209,22 +1369,22 @@ dependencies = [
 
 [[package]]
 name = "raftify"
-version = "0.1.78"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42c008e7e6a5b6431062fac27c4b61e7a78a7e87feeffba5d44d80cfdd657d8"
+checksum = "623a229ebdc881f3f6d3f6c091db8271319f0405a4ce312ca9b1e38ace2000b3"
 dependencies = [
  "async-trait",
  "bincode",
  "built",
  "bytes",
  "chrono",
- "clap",
  "heed",
  "heed-traits",
  "jopemachine-raft",
  "log",
  "parking_lot",
  "prost",
+ "rocksdb",
  "serde",
  "serde_json",
  "slog",
@@ -1237,12 +1397,13 @@ dependencies = [
 
 [[package]]
 name = "raftify_cli"
-version = "0.1.1"
+version = "0.1.80"
 dependencies = [
  "built",
  "clap",
  "log",
  "raftify",
+ "rocksdb",
  "serde",
  "serde_json",
  "slog",
@@ -1329,10 +1490,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1345,6 +1537,37 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -1364,6 +1587,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "semver"
@@ -1519,6 +1752,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"
@@ -1709,6 +1948,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1996,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
  "base64",
@@ -1761,7 +2011,9 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -1873,6 +2125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +2146,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
@@ -2103,4 +2367,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "raftify_cli"
-version = "0.1.1"
+version = "0.1.80"
 edition = "2021"
 description = "Raftify CLI tool"
 license = "MIT/Apache-2.0"
@@ -12,7 +12,7 @@ serde_json = "1.0"
 slog = "2"
 built = "0.5"
 clap = { version = "4.5.18", features = ["derive"] }
-raftify = { version = "0.1.78", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
+raftify = { version = "=0.1.80", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 rocksdb = "0.19.0"
 
 [lib]

--- a/raftify-cli/src/commands/debug.rs
+++ b/raftify-cli/src/commands/debug.rs
@@ -102,7 +102,8 @@ pub fn debug_persitsted_all<LogStorage: StableStorage>(path_str: &str, logger: s
 }
 
 pub async fn debug_node(addr: &str) -> Result<()> {
-    let mut client = create_client(&addr).await?;
+    // TODO: Support TLS configuration
+    let mut client = create_client(&addr, None).await?;
     let response = client.debug_node(raft_service::Empty {}).await?;
     let json = response.into_inner().result_json;
     let parsed: HashMap<String, Value> = serde_json::from_str(&json).unwrap();

--- a/raftify-cli/src/commands/debug.rs
+++ b/raftify-cli/src/commands/debug.rs
@@ -3,26 +3,21 @@ use serde_json::Value;
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
 
 use raftify::{
-    create_client,
-    raft::{
+    create_client, raft::{
         formatter::{format_entry, format_snapshot},
         logger::Slogger,
         Storage,
-    },
-    raft_node::utils::format_debugging_info,
-    raft_service, Config, Result, StableStorage,
-    HeedStorage, StorageType,
+    }, raft_node::utils::format_debugging_info, raft_service, Config, ConfigBuilder, HeedStorage, Result, StableStorage, StorageType
 };
 
 pub fn debug_persisted<LogStorage: StableStorage>(path: &str, logger: slog::Logger) -> Result<()> {
-    let config = Config {
-        log_dir: path.to_string(),
-        ..Default::default()
-    };
+    let config = ConfigBuilder::new()
+        .log_dir(path.to_string())
+        .build();
 
     let storage = match LogStorage::STORAGE_TYPE {
         StorageType::Heed => HeedStorage::create(
-            config.log_dir.as_str(),
+            config.get_log_dir(),
             &config,
             Arc::new(Slogger {
                 slog: logger.clone(),
@@ -60,7 +55,7 @@ pub fn debug_persisted<LogStorage: StableStorage>(path: &str, logger: slog::Logg
     Ok(())
 }
 
-pub fn debug_persitsted_all<LogStorage: StableStorage>(path_str: &str, logger: slog::Logger) -> Result<()> {
+pub fn debug_persisted_all<LogStorage: StableStorage>(path_str: &str, logger: slog::Logger) -> Result<()> {
     let path = match fs::canonicalize(Path::new(&path_str)) {
         Ok(absolute_path) => absolute_path,
         Err(e) => {

--- a/raftify/Cargo.toml
+++ b/raftify/Cargo.toml
@@ -23,7 +23,7 @@ slog = "2"
 slog-stdlog = "4"
 thiserror = "1.0"
 tokio = { version = "1.40", features = ["full"] }
-tonic = "0.9.2"
+tonic = { version = "0.9.2" }
 built = "0.5"
 chrono = "0.4.38"
 heed = { version = "0.20.5", optional = true }
@@ -31,10 +31,11 @@ heed-traits = { version = "0.20", optional = true }
 rocksdb = { version = "0.19.0", optional = true }
 
 [features]
-default = ["heed_storage"]
+default = ["heed_storage", "tls"]
 inmemory_storage = []
 heed_storage =["heed", "heed-traits"]
 rocksdb_storage = ["rocksdb"]
+tls = ["tonic/tls"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/raftify/src/config.rs
+++ b/raftify/src/config.rs
@@ -1,56 +1,132 @@
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{error::Error, raft::Config as RaftConfig, InitialRole, Peers, Result};
+
+// NOTE: This TLS Config is a type commonly used in both RaftServer and RaftClient.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TlsConfig {
+    pub cert_path: Option<String>,
+    pub key_path: Option<String>,
+    pub ca_cert_path: Option<String>,
+    pub domain_name: Option<String>,
+}
 
 #[derive(Clone)]
 pub struct Config {
-    pub raft_config: RaftConfig,
-    pub log_dir: String,
-
-    pub bootstrap_from_snapshot: bool,
-    pub save_compacted_logs: bool,
-    pub compacted_log_dir: String,
-    pub compacted_log_size_threshold: u64,
-
-    pub tick_interval: f32,
-    pub lmdb_map_size: u64,
-    pub cluster_id: String,
-    pub conf_change_request_timeout: f32,
-
-    pub initial_peers: Option<Peers>,
-    pub snapshot_interval: Option<f32>,
+    pub(crate) raft_config: RaftConfig,
+    pub(crate) log_dir: String,
+    pub(crate) save_compacted_logs: bool,
+    pub(crate) compacted_log_dir: String,
+    pub(crate) compacted_log_size_threshold: u64,
+    pub(crate) tick_interval: f32,
+    pub(crate) lmdb_map_size: u64,
+    pub(crate) bootstrap_from_snapshot: bool,
+    pub(crate) cluster_id: String,
+    pub(crate) conf_change_request_timeout: f32,
+    pub(crate) initial_peers: Option<Peers>,
+    pub(crate) snapshot_interval: Option<f32>,
+    pub(crate) client_tls_config: Option<TlsConfig>,
+    pub(crate) server_tls_config: Option<TlsConfig>,
 }
 
-impl Config {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        log_dir: String,
-        save_compacted_logs: bool,
-        compacted_log_dir: String,
-        compacted_log_size_threshold: u64,
-        raft_config: RaftConfig,
-        tick_interval: f32,
-        lmdb_map_size: u64,
-        cluster_id: String,
-        bootstrap_from_snapshot: bool,
-        conf_change_request_timeout: f32,
-        initial_peers: Option<Peers>,
-        snapshot_interval: Option<f32>,
-    ) -> Self {
+pub struct ConfigBuilder {
+    config: Config,
+    global_client_tls_config: Option<TlsConfig>,
+}
+
+impl ConfigBuilder {
+    pub fn new() -> Self {
         Self {
-            raft_config,
-            log_dir,
-            save_compacted_logs,
-            compacted_log_dir,
-            compacted_log_size_threshold,
-            snapshot_interval,
-            tick_interval,
-            lmdb_map_size,
-            initial_peers,
-            cluster_id,
-            conf_change_request_timeout,
-            bootstrap_from_snapshot,
+            config: Config::default(),
+            global_client_tls_config: None,
         }
+    }
+
+    pub fn log_dir(mut self, log_dir: String) -> Self {
+        self.config.log_dir = log_dir;
+        self
+    }
+
+    pub fn save_compacted_logs(mut self, save: bool) -> Self {
+        self.config.save_compacted_logs = save;
+        self
+    }
+
+    pub fn compacted_log_dir(mut self, dir: String) -> Self {
+        self.config.compacted_log_dir = dir;
+        self
+    }
+
+    pub fn compacted_log_size_threshold(mut self, threshold: u64) -> Self {
+        self.config.compacted_log_size_threshold = threshold;
+        self
+    }
+
+    pub fn raft_config(mut self, raft_config: RaftConfig) -> Self {
+        self.config.raft_config = raft_config;
+        self
+    }
+
+    pub fn tick_interval(mut self, interval: f32) -> Self {
+        self.config.tick_interval = interval;
+        self
+    }
+
+    pub fn lmdb_map_size(mut self, size: u64) -> Self {
+        self.config.lmdb_map_size = size;
+        self
+    }
+
+    pub fn cluster_id(mut self, cluster_id: String) -> Self {
+        self.config.cluster_id = cluster_id;
+        self
+    }
+
+    pub fn conf_change_request_timeout(mut self, timeout: f32) -> Self {
+        self.config.conf_change_request_timeout = timeout;
+        self
+    }
+
+    pub fn initial_peers(mut self, peers: Peers) -> Self {
+        self.config.initial_peers = Some(peers);
+        self
+    }
+
+    pub fn snapshot_interval(mut self, interval: f32) -> Self {
+        self.config.snapshot_interval = Some(interval);
+        self
+    }
+
+    pub fn server_tls_config(mut self, config: TlsConfig) -> Self {
+        self.config.server_tls_config = Some(config);
+        self
+    }
+
+    pub fn bootstrap_from_snapshot(mut self, v: bool) -> Self {
+        self.config.bootstrap_from_snapshot = v;
+        self
+    }
+
+    pub fn global_client_tls_config(mut self, config: TlsConfig) -> Self {
+        self.global_client_tls_config = Some(config);
+        self
+    }
+
+    pub fn build(mut self) -> Config {
+        self.config.client_tls_config = self.global_client_tls_config.clone();
+
+        if let Some(mut initial_peers) = self.config.initial_peers.clone() {
+            if let Some(self_peer) = initial_peers.get_mut(&self.config.raft_config.id) {
+                if self_peer.client_tls_config.is_none() {
+                    self_peer.client_tls_config = self.global_client_tls_config.clone();
+                }
+            }
+            self.config.initial_peers = Some(initial_peers);
+        }
+
+        self.config
     }
 }
 
@@ -63,7 +139,7 @@ impl Config {
                 .unwrap()
                 .inner
                 .into_iter()
-                .filter(|(_, peer)| peer.role == InitialRole::Leader)
+                .filter(|(_, peer)| peer.initial_role == InitialRole::Leader)
                 .map(|(key, _)| key)
                 .collect::<Vec<_>>();
 
@@ -76,6 +152,10 @@ impl Config {
 
         self.raft_config.validate()?;
         Ok(())
+    }
+
+    pub fn get_log_dir(&self) -> &str {
+        &self.log_dir
     }
 }
 
@@ -94,6 +174,8 @@ impl Default for Config {
             initial_peers: None,
             snapshot_interval: None,
             bootstrap_from_snapshot: false,
+            client_tls_config: None,
+            server_tls_config: None,
         }
     }
 }
@@ -132,6 +214,8 @@ impl fmt::Debug for Config {
                 lmdb_map_size: {lmdb_map_size}, \
                 cluster_id: {cluster_id}, \
                 conf_change_request_timeout: {conf_change_request_timeout}, \
+                client_tls_config: {client_tls_config:?}, \
+                server_tls_config: {server_tls_config:?}, \
             }}",
             id = self.raft_config.id,
             election_tick = self.raft_config.election_tick,
@@ -160,6 +244,8 @@ impl fmt::Debug for Config {
             cluster_id = self.cluster_id,
             conf_change_request_timeout = self.conf_change_request_timeout,
             bootstrap_from_snapshot = self.bootstrap_from_snapshot,
+            client_tls_config = self.client_tls_config,
+            server_tls_config = self.server_tls_config,
         )
     }
 }

--- a/raftify/src/config.rs
+++ b/raftify/src/config.rs
@@ -121,6 +121,8 @@ impl ConfigBuilder {
             if let Some(self_peer) = initial_peers.get_mut(&self.config.raft_config.id) {
                 if self_peer.client_tls_config.is_none() {
                     self_peer.client_tls_config = self.global_client_tls_config.clone();
+                } else {
+                    self.config.client_tls_config = self_peer.client_tls_config.clone();
                 }
             }
             self.config.initial_peers = Some(initial_peers);

--- a/raftify/src/error.rs
+++ b/raftify/src/error.rs
@@ -45,11 +45,11 @@ pub enum Error {
 
 #[derive(Debug, ThisError)]
 pub enum SendMessageError {
-    #[error("Failed to connect to node {0}")]
+    #[error("Failed to connect to node. {0}")]
     ConnectionError(String),
     #[error("Node {0} not found from the peers")]
     PeerNotFound(String),
-    #[error("Failed to send message to node {0}")]
+    #[error("Failed to send message. {0}")]
     TransmissionError(String),
 }
 

--- a/raftify/src/lib.rs
+++ b/raftify/src/lib.rs
@@ -25,7 +25,7 @@ pub use {
 
 pub use crate::{
     cluster_join_ticket::ClusterJoinTicket,
-    config::Config,
+    config::{Config, ConfigBuilder, TlsConfig},
     error::{Error, Result},
     log_entry::AbstractLogEntry,
     peer::Peer,

--- a/raftify/src/raft_client.rs
+++ b/raftify/src/raft_client.rs
@@ -1,23 +1,64 @@
-use bytes::Bytes;
 use std::net::ToSocketAddrs;
 use tonic::transport::{Channel, Error as TonicError};
+
+#[cfg(feature = "tls")]
+use tonic::transport::{Certificate, ClientTlsConfig, Identity};
+
+use crate::config::TlsConfig;
 
 use super::RaftServiceClient;
 
 // TODO: Support https schema
 pub async fn create_client<A: ToSocketAddrs>(
     addr: A,
+    client_tls_config: Option<TlsConfig>,
 ) -> Result<RaftServiceClient<Channel>, TonicError> {
-    let addr = addr
-        .to_socket_addrs()
-        .expect("Invalid socket address format")
-        .next()
-        .unwrap();
-    let addr = format!("http://{}", addr);
-    let addr = Bytes::copy_from_slice(addr.as_bytes());
+    let addr = addr.to_socket_addrs().unwrap().next().unwrap();
 
-    let channel = Channel::from_shared(addr).unwrap().connect().await?;
+    let scheme = if client_tls_config.is_some() {
+        "https"
+    } else {
+        "http"
+    };
+
+    let addr = format!("{}://{}", scheme, addr);
+
+    #[allow(unused_mut)]
+    let mut endpoint = Channel::from_shared(addr).unwrap();
+
+    #[cfg(feature = "tls")]
+    if let Some(tls_cfg) = client_tls_config {
+        let ca_cert_path = tls_cfg.ca_cert_path.as_ref().unwrap();
+        let ca_cert = tokio::fs::read(ca_cert_path).await.unwrap();
+        let ca_cert = Certificate::from_pem(ca_cert);
+
+        let domain_name = tls_cfg
+            .domain_name
+            .unwrap_or_else(|| "localhost".to_string());
+
+        let mut client_tls_config = ClientTlsConfig::new()
+            .ca_certificate(ca_cert)
+            .domain_name(domain_name);
+
+        // mTLS
+        if let (Some(cert_path), Some(key_path)) =
+            (tls_cfg.cert_path.clone(), tls_cfg.key_path.clone())
+        {
+            let cert = tokio::fs::read(cert_path).await.unwrap();
+            let key = tokio::fs::read(key_path).await.unwrap();
+            let identity = Identity::from_pem(cert, key);
+            client_tls_config = client_tls_config.identity(identity);
+        }
+
+        endpoint = endpoint.tls_config(client_tls_config)?;
+    }
+
+    let channel = endpoint.connect().await?;
     let client = RaftServiceClient::new(channel);
 
     Ok(client)
 }
+
+// TODO: Implement test_create_client
+#[cfg(test)]
+mod test {}

--- a/raftify/src/raft_client.rs
+++ b/raftify/src/raft_client.rs
@@ -8,7 +8,6 @@ use crate::config::TlsConfig;
 
 use super::RaftServiceClient;
 
-// TODO: Support https schema
 pub async fn create_client<A: ToSocketAddrs>(
     addr: A,
     client_tls_config: Option<TlsConfig>,

--- a/raftify/src/raft_client.rs
+++ b/raftify/src/raft_client.rs
@@ -33,7 +33,7 @@ pub async fn create_client<A: ToSocketAddrs>(
 
         let domain_name = tls_cfg
             .domain_name
-            .unwrap_or_else(|| "localhost".to_string());
+            .expect("Domain name is required for TLS");
 
         let mut client_tls_config = ClientTlsConfig::new()
             .ca_certificate(ca_cert)

--- a/raftify/src/raft_node/mod.rs
+++ b/raftify/src/raft_node/mod.rs
@@ -51,7 +51,7 @@ use crate::{
     },
     utils::{membership::to_confchange_v2, oneshot_mutex::OneShotMutex},
     AbstractLogEntry, AbstractStateMachine, ClusterJoinTicket, Config, Error, InitialRole, Peers,
-    RaftServiceClient, StableStorage,
+    StableStorage,
 };
 
 #[derive(Clone)]
@@ -770,8 +770,9 @@ impl<
         let cc_v2: ConfChangeRequest = cc_v2.clone().into();
         let cc_v2: raft_service::ChangeConfigArgs = cc_v2.into();
 
-        // TODO: Apply TLS
-        let mut leader_client = RaftServiceClient::connect(format!("http://{}", peer_addr)).await?;
+        let mut leader_client =
+            create_client(peer_addr, self.config.client_tls_config.clone()).await?;
+
         let response = leader_client
             .change_config(cc_v2.clone())
             .await?

--- a/raftify/src/storage/heed_storage/mod.rs
+++ b/raftify/src/storage/heed_storage/mod.rs
@@ -553,7 +553,7 @@ mod test {
         logger::Slogger,
         Config as RaftConfig, Error as RaftError, GetEntriesContext, Storage, StorageError,
     };
-    use crate::{Config, HeedStorage, StableStorage};
+    use crate::{Config, ConfigBuilder, HeedStorage, StableStorage};
     use prost::Message;
 
     fn new_entry(index: u64, term: u64) -> Entry {
@@ -582,14 +582,13 @@ mod test {
             ..Default::default()
         };
 
-        Config {
-            log_dir: test_dir_pth.to_owned(),
-            save_compacted_logs: false,
-            compacted_log_dir: test_dir_pth.to_owned(),
-            compacted_log_size_threshold: 1024 * 1024 * 1024,
-            raft_config,
-            ..Default::default()
-        }
+        ConfigBuilder::new()
+            .log_dir(test_dir_pth.to_owned())
+            .save_compacted_logs(false)
+            .compacted_log_dir(test_dir_pth.to_owned())
+            .compacted_log_size_threshold(1024 * 1024 * 1024)
+            .raft_config(raft_config)
+            .build()
     }
 
     pub fn build_logger() -> slog::Logger {


### PR DESCRIPTION
Resolves #18.

- Support for TLS encrypted network connections between RaftNodes
- Refactoring of code to generate Config using `ConfigBuilder`

## How to test

After executing the following command, enable the TLS feature in the example code's cargo.toml and bootstrap the cluster.

```
openssl genrsa -out server.key 2048 ; \
echo "[ req ]
default_bits       = 2048
default_md         = sha256
default_keyfile    = server.key
distinguished_name = req_distinguished_name
req_extensions     = req_ext
x509_extensions    = v3_req
prompt             = no

[ req_distinguished_name ]
C  = KR
ST = Seoul
L  = Seoul
O  = MyOrganization
OU = MyUnit
CN = localhost

[ req_ext ]
subjectAltName = @alt_names

[ v3_req ]
subjectAltName = @alt_names

[ alt_names ]
DNS.1 = localhost
IP.1  = 127.0.0.1" > openssl.cnf ; \
openssl req -new -key server.key -out server.csr -config openssl.cnf ; \
openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt -extensions v3_req -extfile openssl.cnf ; \
cp server.crt ca_cert.pem
```