### PR TITLE
fix: Correct wrong `GET` http method usage in example code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,15 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "autotools"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1459,8 @@ dependencies = [
 [[package]]
 name = "jopemachine-raft"
 version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d59de55fd63e47d77aee8845a8380d06432594e9ff55cb2d953ca98bb4f084a"
 dependencies = [
  "bytes",
  "fxhash",
@@ -2139,26 +2132,15 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-build"
-version = "0.15.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
+checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
 dependencies = [
  "bitflags 1.3.2",
  "proc-macro2",
  "prost-build",
- "protobuf-src",
  "quote",
- "regex",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "protobuf-src"
-version = "1.1.0+21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
-dependencies = [
- "autotools",
 ]
 
 [[package]]
@@ -2173,6 +2155,8 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
 dependencies = [
  "lazy_static",
  "prost",
@@ -3450,3 +3434,7 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "jopemachine-raft"
+version = "0.7.9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "autotools"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef941527c41b0fc0dd48511a8154cd5fc7e29200a0ff8b7203c5d777dbc795cf"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1459,8 +1468,6 @@ dependencies = [
 [[package]]
 name = "jopemachine-raft"
 version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d59de55fd63e47d77aee8845a8380d06432594e9ff55cb2d953ca98bb4f084a"
 dependencies = [
  "bytes",
  "fxhash",
@@ -2132,15 +2139,26 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf-build"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df9942df2981178a930a72d442de47e2f0df18ad68e50a30f816f1848215ad0"
+checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
 dependencies = [
  "bitflags 1.3.2",
  "proc-macro2",
  "prost-build",
+ "protobuf-src",
  "quote",
+ "regex",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "1.1.0+21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7ac8852baeb3cc6fb83b93646fb93c0ffe5d14bf138c945ceb4b9948ee0e3c1"
+dependencies = [
+ "autotools",
 ]
 
 [[package]]
@@ -2155,8 +2173,6 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6884896294f553e8d5cfbdb55080b9f5f2f43394afff59c9f077e0f4b46d6b"
 dependencies = [
  "lazy_static",
  "prost",
@@ -3434,7 +3450,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "jopemachine-raft"
-version = "0.7.9"

--- a/examples/memstore/src/web_server_api.rs
+++ b/examples/memstore/src/web_server_api.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use actix_web::{get, put, web, HttpResponse, Responder};
+use actix_web::{get, post, put, web, HttpResponse, Responder};
 use raftify::{raft::Storage, AbstractLogEntry, StableStorage};
 use serde_json::Value;
 
@@ -39,7 +39,7 @@ async fn leader(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     format!("{:?}", leader_id)
 }
 
-#[get("/leave")]
+#[post("/leave")]
 async fn leave(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     let raft = data.clone();
     raft.1.leave().await.unwrap();
@@ -61,7 +61,7 @@ async fn peers(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     format!("{:?}", peers)
 }
 
-#[get("/snapshot")]
+#[post("/snapshot")]
 async fn snapshot(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     #[cfg(feature = "inmemory_storage")]
     {
@@ -95,14 +95,14 @@ async fn snapshot(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     }
 }
 
-#[get("/leave_joint")]
+#[post("/leave_joint")]
 async fn leave_joint(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     let raft = data.clone();
     raft.1.leave_joint().await;
     "OK".to_string()
 }
 
-#[get("/transfer_leader/{id}")]
+#[post("/transfer_leader/{id}")]
 async fn transfer_leader(
     data: web::Data<(HashStore, Raft)>,
     path: web::Path<u64>,
@@ -113,14 +113,14 @@ async fn transfer_leader(
     "OK".to_string()
 }
 
-#[get("/campaign")]
+#[post("/campaign")]
 async fn campaign(data: web::Data<(HashStore, Raft)>) -> impl Responder {
     let raft = data.clone();
     raft.1.campaign().await.unwrap();
     "OK".to_string()
 }
 
-#[get("/demote/{term}/{leader_id}")]
+#[post("/demote/{term}/{leader_id}")]
 async fn demote(data: web::Data<(HashStore, Raft)>, path: web::Path<(u64, u64)>) -> impl Responder {
     let raft = data.clone();
     let (term, leader_id) = path.into_inner();


### PR DESCRIPTION
This PR corrects the incorrect usage of the GET method in the example code as described in issue #120. It ensures that methods like `leave_joint` and `campaign` do not use the GET method. Additionally, it updates the PUT method to pass values in the request body rather than the path.

Changes made in both Python and Rust code examples.
