### PR TITLE
feat: Add code lint, formatting check in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Integration Test
+name: CI
 
 on:
   push:
@@ -11,7 +11,7 @@ permissions:
   contents: read
 
 jobs:
-  test-lint:
+  check-lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -31,7 +31,7 @@ jobs:
         git submodule update --init
         cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
 
-  test-formatting:
+  check-fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,14 @@ jobs:
         make test
         cd ../../
 
+    - name: Run Rust code fomatter
+      run: cargo fmt --check
+
+    - name: Lint Rust codes
+      run: |
+        cargo clippy
+
+
   test-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,10 @@ jobs:
         toolchain: stable
         override: true
 
+    - name: Install protobuf compiler
+      run: |
+          sudo apt install -y protobuf-compiler
+
     - name: Run Rust code lint
       run: |
         git submodule update --init

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Lint Rust codes
       run: |
-        cargo clippy
+        cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
 
 
   test-windows:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
         override: true
 
     - name: Run Rust code lint
-      run: cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
+      run: |
+        git submodule update --init
+        cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
 
   test-formatting:
     runs-on: ubuntu-latest
@@ -37,7 +39,9 @@ jobs:
         override: true
 
     - name: Run Rust code fomatter
-      run: cargo fmt --check
+      run: |
+        git submodule update --init
+        cargo fmt --check
 
   test-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,34 @@ permissions:
   contents: read
 
 jobs:
+  test-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Run Rust code lint
+      run: cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
+
+  test-formatting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Run Rust code fomatter
+      run: cargo fmt --check
+
   test-linux:
     runs-on: ubuntu-latest
     steps:
@@ -47,14 +75,6 @@ jobs:
         pip3 install -r requirements.txt
         make test
         cd ../../
-
-    - name: Run Rust code fomatter
-      run: cargo fmt --check
-
-    - name: Lint Rust codes
-      run: |
-        cargo clippy --manifest-path=raftify/Cargo.toml -- -D warnings
-
 
   test-windows:
     runs-on: windows-latest

--- a/raftify/build.rs
+++ b/raftify/build.rs
@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .extern_path(".eraftpb", "::raft::eraftpb")
         .compile(&["proto/raft_service.proto"], &["proto/"])?;
 
-
     built::write_built_file().expect("Failed to acquire build-time information");
     Ok(())
 }

--- a/raftify/build.rs
+++ b/raftify/build.rs
@@ -5,6 +5,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .extern_path(".eraftpb", "::raft::eraftpb")
         .compile(&["proto/raft_service.proto"], &["proto/"])?;
 
+
     built::write_built_file().expect("Failed to acquire build-time information");
     Ok(())
 }

--- a/raftify/src/storage/rocksdb_storage/mod.rs
+++ b/raftify/src/storage/rocksdb_storage/mod.rs
@@ -38,11 +38,13 @@ impl RocksDBStorage {
     }
 
     pub fn open_readonly(log_dir_path: &str, logger: Arc<dyn Logger>) -> Result<Self> {
-        Ok(Self(Arc::new(RwLock::new(RocksDBStorageCore::open_readonly(
-            Path::new(log_dir_path).to_path_buf(),
-            // config,
-            logger,
-        )?))))
+        Ok(Self(Arc::new(RwLock::new(
+            RocksDBStorageCore::open_readonly(
+                Path::new(log_dir_path).to_path_buf(),
+                // config,
+                logger,
+            )?,
+        ))))
     }
 
     fn wl(&mut self) -> RwLockWriteGuard<RocksDBStorageCore> {
@@ -190,7 +192,8 @@ impl RocksDBStorageCore {
             ColumnFamilyDescriptor::new(METADATA_CF_KEY, cf_opts.clone()),
         ];
 
-        let db = RocksDB::open_cf_descriptors_read_only(&db_opts, path, cf_descriptors, false).unwrap();
+        let db =
+            RocksDB::open_cf_descriptors_read_only(&db_opts, path, cf_descriptors, false).unwrap();
         Ok(RocksDBStorageCore { db, logger })
     }
 


### PR DESCRIPTION
Resolves: #126 
I have added the CI used by other Rust projects. Now can always check the code in the CI stage.

In addition, the formatting was modified in the existing code (by rust 1.81.0)