### PR TITLE
Integration of pyo3-stub-gen.....

### DIFF
--- a/binding/python/Cargo.lock
+++ b/binding/python/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -115,6 +115,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +184,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -268,18 +319,15 @@ checksum = "031718ddb8f78aa5def78a09e90defe30151d1f6c672f937af4dd916429ed996"
 dependencies = [
  "semver",
  "serde",
- "toml",
+ "toml 0.5.11",
  "url",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.22"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
-dependencies = [
- "shlex",
-]
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"
@@ -303,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
+checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -313,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.18"
+version = "4.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
+checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -333,6 +381,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.79",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -622,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
@@ -638,7 +703,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -660,6 +725,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -756,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -847,12 +918,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -874,6 +945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
  "hermit-abi 0.4.0",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -894,6 +966,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,9 +982,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jopemachine-raft"
-version = "0.7.10"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b3af8ccd4a755cac94abb0f0692544dfb10869f64dbc19b69ab73c6e251"
+checksum = "2d59de55fd63e47d77aee8845a8380d06432594e9ff55cb2d953ca98bb4f084a"
 dependencies = [
  "bytes",
  "fxhash",
@@ -912,6 +993,7 @@ dependencies = [
  "protobuf",
  "raft-proto",
  "rand",
+ "serde",
  "slog",
  "slog-envlogger",
  "slog-stdlog",
@@ -1049,7 +1131,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1078,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "memchr",
 ]
@@ -1093,6 +1175,7 @@ checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
 dependencies = [
  "portable-atomic",
 ]
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "page_size"
@@ -1140,7 +1223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -1297,7 +1380,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -1318,7 +1401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1426,7 +1509,33 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "pyo3-stub-gen"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180adeee3722c15114f5f7889e72902ce89c3acdd776e532ce022cc6af35a018"
+dependencies = [
+ "anyhow",
+ "inventory",
+ "itertools 0.12.1",
+ "pyo3",
+ "pyo3-stub-gen-derive",
+ "serde",
+ "toml 0.8.19",
+]
+
+[[package]]
+name = "pyo3-stub-gen-derive"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fa7a2dad5f93553280ea4590bfc048af5ea77d23b5855f14c6a5603a7bbc8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1465,6 +1574,7 @@ name = "raftify"
 version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f42c008e7e6a5b6431062fac27c4b61e7a78a7e87feeffba5d44d80cfdd657d8"
+version = "0.1.68"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1500,6 +1610,7 @@ dependencies = [
  "prost",
  "pyo3",
  "pyo3-asyncio",
+ "pyo3-stub-gen",
  "pythonize",
  "raftify",
  "raftify_cli",
@@ -1561,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.6"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -1698,6 +1809,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -2076,6 +2196,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,9 +2360,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -2466,6 +2620,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/binding/python/Cargo.toml
+++ b/binding/python/Cargo.toml
@@ -33,9 +33,14 @@ bincode = "1.3.3"
 bytes = "1.0"
 once_cell = "1.7"
 prost = "0.11"
-
-[lib]
-name = "raftify"
-crate-type = ["cdylib"]
+pyo3-stub-gen = "0.1.0"
 
 [workspace]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "stub_gen"
+path = "src/bin/stub_gen.rs"
+doc = false

--- a/binding/python/src/bin/stub_gen.rs
+++ b/binding/python/src/bin/stub_gen.rs
@@ -1,0 +1,10 @@
+use pyo3_stub_gen::Result;
+// Specify the exact path to the desired `raftify` crate
+
+fn main() -> Result<()> {
+    // `stub_info` is a function defined by `define_stub_info_gatherer!` macro.
+    let stub = raftify_py::stub_info()?;
+
+    stub.generate()?;
+    Ok(())
+}

--- a/binding/python/src/bindings/slogger.rs
+++ b/binding/python/src/bindings/slogger.rs
@@ -1,4 +1,5 @@
 use pyo3::{prelude::*, types::PyString};
+use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 use raftify::raft::{default_logger, logger::Logger};
 use slog::{crit, debug, error, info, o, trace, warn, Logger as Slogger};
 use slog_async::OverflowStrategy;
@@ -32,6 +33,7 @@ impl From<PySeverity> for Severity {
     }
 }
 
+#[gen_stub_pyclass]
 #[pyclass(name = "OverflowStrategy")]
 pub struct PyOverflowStrategy(pub OverflowStrategy);
 
@@ -46,6 +48,7 @@ impl From<OverflowStrategy> for PyOverflowStrategy {
     }
 }
 
+#[gen_stub_pymethods]
 #[pymethods]
 impl PyOverflowStrategy {
     pub fn __hash__(&self) -> u64 {
@@ -77,6 +80,7 @@ impl PyOverflowStrategy {
     }
 }
 
+#[gen_stub_pyclass]
 #[derive(Clone, Debug)]
 #[pyclass(name = "Slogger")]
 pub struct PySlogger {
@@ -109,6 +113,7 @@ impl Logger for PySlogger {
     }
 }
 
+#[gen_stub_pymethods]
 #[pymethods]
 impl PySlogger {
     #[new]

--- a/binding/python/src/lib.rs
+++ b/binding/python/src/lib.rs
@@ -2,6 +2,7 @@
 use ::raftify::raft::formatter::set_custom_formatter;
 use bindings::formatter::PythonFormatter;
 use pyo3::prelude::*;
+use pyo3_stub_gen::define_stub_info_gatherer;
 
 mod bindings;
 
@@ -102,3 +103,5 @@ fn raftify(py: Python, m: &PyModule) -> PyResult<()> {
 
     Ok(())
 }
+
+define_stub_info_gatherer!(stub_info);

--- a/raftify/src/raft_node/mod.rs
+++ b/raftify/src/raft_node/mod.rs
@@ -1152,7 +1152,7 @@ impl<
                 tx_msg
                     .send(LocalResponseMsg::GetRawNode {
                         raw_node: Arc::new(Mutex::new(unsafe {
-                            #[allow(clippy::missing_transmute_annotations)]
+                            // #[allow(clippy::missing_transmute_annotations)]
                             std::mem::transmute(&self.raw_node)
                         })),
                     })

--- a/raftify/src/storage/rocksdb_storage/mod.rs
+++ b/raftify/src/storage/rocksdb_storage/mod.rs
@@ -38,11 +38,13 @@ impl RocksDBStorage {
     }
 
     pub fn open_readonly(log_dir_path: &str, logger: Arc<dyn Logger>) -> Result<Self> {
-        Ok(Self(Arc::new(RwLock::new(RocksDBStorageCore::open_readonly(
-            Path::new(log_dir_path).to_path_buf(),
-            // config,
-            logger,
-        )?))))
+        Ok(Self(Arc::new(RwLock::new(
+            RocksDBStorageCore::open_readonly(
+                Path::new(log_dir_path).to_path_buf(),
+                // config,
+                logger,
+            )?,
+        ))))
     }
 
     fn wl(&mut self) -> RwLockWriteGuard<RocksDBStorageCore> {
@@ -190,7 +192,8 @@ impl RocksDBStorageCore {
             ColumnFamilyDescriptor::new(METADATA_CF_KEY, cf_opts.clone()),
         ];
 
-        let db = RocksDB::open_cf_descriptors_read_only(&db_opts, path, cf_descriptors, false).unwrap();
+        let db =
+            RocksDB::open_cf_descriptors_read_only(&db_opts, path, cf_descriptors, false).unwrap();
         Ok(RocksDBStorageCore { db, logger })
     }
 


### PR DESCRIPTION
This PR introduces pyo3-stub-gen into the project to automate the generation of Python interface type hint files (.pyi) from Rust code.

However, during the integration process, several compatibility issues were encountered.




## 1. Our project currently uses pyo3 0.20.3, (primarily due to the dependency on pyo3-asyncio..?) which is incompatible with pyo3 0.21.0.

This version mismatch leads to compilation failures when trying to run the stub generator, specifically when executing `cargo run --bin stub_gen` as per the documentation.

## 2. Errors from Example Code:

The provided example code results in errors when following the documented steps to generate stubs. 

<img width="998" alt="image" src="https://github.com/user-attachments/assets/bc534cf6-dc8d-4294-8bc5-bb43bff6b6c0">
