### PR TITLE
feat: Pretty print persisted log entries in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,6 +956,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2023,6 +2050,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2256,7 @@ dependencies = [
  "built",
  "clap 4.5.19",
  "log",
+ "prettytable-rs",
  "raftify",
  "rocksdb",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +856,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,27 +891,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -956,12 +969,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2050,20 +2057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,8 +2248,8 @@ version = "0.1.81"
 dependencies = [
  "built",
  "clap 4.5.19",
+ "comfy-table",
  "log",
- "prettytable-rs",
  "raftify",
  "rocksdb",
  "serde",
@@ -2728,6 +2721,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/raftify-cli/Cargo.lock
+++ b/raftify-cli/Cargo.lock
@@ -408,6 +408,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +506,28 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.6.0",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1599,6 +1633,7 @@ version = "0.1.81"
 dependencies = [
  "built",
  "clap",
+ "comfy-table",
  "log",
  "raftify",
  "rocksdb",
@@ -2004,6 +2039,25 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "syn"
@@ -2424,6 +2478,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -14,6 +14,7 @@ built = "0.5"
 clap = { version = "4.5.18", features = ["derive"] }
 raftify = { version = "=0.1.81", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 rocksdb = "0.19.0"
+prettytable-rs = "^0.10"
 
 [lib]
 name = "raftify_cli"

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -14,7 +14,7 @@ built = "0.5"
 clap = { version = "4.5.18", features = ["derive"] }
 raftify = { version = "=0.1.81", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 rocksdb = "0.19.0"
-prettytable-rs = "^0.10"
+comfy-table = "7.1.1"
 
 [lib]
 name = "raftify_cli"

--- a/raftify-cli/src/commands/debug.rs
+++ b/raftify-cli/src/commands/debug.rs
@@ -1,5 +1,5 @@
+use comfy_table::{Cell, CellAlignment, ContentArrangement, Table};
 use core::panic;
-use prettytable::*;
 use serde_json::Value;
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
 
@@ -14,7 +14,11 @@ use raftify::{
     raft_service, ConfigBuilder, HeedStorage, Result, StableStorage, StorageType,
 };
 
-pub fn debug_persisted<LogStorage: StableStorage>(path: &str, logger: slog::Logger) -> Result<()> {
+pub fn debug_persisted<LogStorage: StableStorage>(
+    path: &str,
+    logger: slog::Logger,
+    print_as_table: bool,
+) -> Result<()> {
     let config = ConfigBuilder::new().log_dir(path.to_string()).build();
 
     let storage = match LogStorage::STORAGE_TYPE {
@@ -43,22 +47,40 @@ pub fn debug_persisted<LogStorage: StableStorage>(path: &str, logger: slog::Logg
     }
 
     println!("---- Persisted entries ----");
-    let mut table = Table::new();
-    let formatter = CUSTOM_FORMATTER.read().unwrap();
 
-    table.add_row(row!["index", "type", "context", "data", "term"]);
+    if print_as_table {
+        let mut table = Table::new();
+        let formatter = CUSTOM_FORMATTER.read().unwrap();
 
-    for entry in entries.iter() {
-        println!("Key: {}, {:?}", entry.get_index(), format_entry(entry));
-        table.add_row(row![
-            entry.get_index(),
-            format!("{:?}", entry.get_entry_type()).replace("Entry", ""),
-            formatter.format_entry_context(&entry.context.clone().into()),
-            formatter.format_entry_data(&entry.data.clone().into()),
-            entry.get_term()
-        ]);
+        table
+            .set_header(vec![
+                Cell::new("index").set_alignment(CellAlignment::Center),
+                Cell::new("type").set_alignment(CellAlignment::Center),
+                Cell::new("data").set_alignment(CellAlignment::Center),
+                Cell::new("term").set_alignment(CellAlignment::Center),
+            ])
+            .set_content_arrangement(ContentArrangement::Dynamic);
+
+        for entry in entries.iter() {
+            table.add_row(vec![
+                Cell::new(entry.get_index()).set_alignment(CellAlignment::Center),
+                Cell::new(
+                    format!("{:?}", entry.get_entry_type())
+                        .replace("Entry", "")
+                        .replace("ConfChangeV2", "ConfChange"),
+                )
+                .set_alignment(CellAlignment::Center),
+                Cell::new(formatter.format_entry_data(&entry.data.clone().into()))
+                    .set_alignment(CellAlignment::Left),
+                Cell::new(entry.get_term()).set_alignment(CellAlignment::Center),
+            ]);
+        }
+        println!("{}", table);
+    } else {
+        for entry in entries.iter() {
+            println!("Key: {}, {:?}", entry.get_index(), format_entry(entry));
+        }
     }
-    table.printstd();
 
     println!();
 
@@ -73,6 +95,7 @@ pub fn debug_persisted<LogStorage: StableStorage>(path: &str, logger: slog::Logg
 pub fn debug_persisted_all<LogStorage: StableStorage>(
     path_str: &str,
     logger: slog::Logger,
+    print_as_table: bool,
 ) -> Result<()> {
     let path = match fs::canonicalize(Path::new(&path_str)) {
         Ok(absolute_path) => absolute_path,
@@ -104,7 +127,11 @@ pub fn debug_persisted_all<LogStorage: StableStorage>(
 
         for name in dir_entries {
             println!("*----- {name} -----*");
-            debug_persisted::<LogStorage>(&format!("{}/{}", path_str, name), logger.clone())?;
+            debug_persisted::<LogStorage>(
+                &format!("{}/{}", path_str, name),
+                logger.clone(),
+                print_as_table,
+            )?;
             println!();
         }
     } else {

--- a/raftify-cli/src/mod.rs
+++ b/raftify-cli/src/mod.rs
@@ -34,11 +34,17 @@ enum DebugSubcommands {
     Persisted {
         /// The log directory path
         path: String,
+        /// Print the output in a table format
+        #[arg(long, default_value_t = false)]
+        table: bool,
     },
     /// List persisted log entries and metadata for all local nodes
     PersistedAll {
         /// The log directory path
         path: String,
+        /// Print the output in a table format
+        #[arg(long, default_value_t = false)]
+        table: bool,
     },
     /// List all log entries
     Entries {
@@ -50,14 +56,6 @@ enum DebugSubcommands {
         /// The address of the RaftNode
         address: String,
     },
-}
-
-#[derive(Args)]
-struct Dump {
-    /// The log directory path
-    path: String,
-    /// The peers to dump
-    peers: String,
 }
 
 pub async fn cli_handler<
@@ -76,11 +74,11 @@ pub async fn cli_handler<
 
     match app.command {
         Commands::Debug(x) => match x {
-            DebugSubcommands::Persisted { path } => {
-                debug_persisted::<LogStorage>(path.as_str(), logger.clone())?;
+            DebugSubcommands::Persisted { path, table } => {
+                debug_persisted::<LogStorage>(path.as_str(), logger.clone(), table)?;
             }
-            DebugSubcommands::PersistedAll { path } => {
-                debug_persisted_all::<LogStorage>(path.as_str(), logger.clone())?;
+            DebugSubcommands::PersistedAll { path, table } => {
+                debug_persisted_all::<LogStorage>(path.as_str(), logger.clone(), table)?;
             }
             DebugSubcommands::Entries { address } => {
                 debug_entries(address.as_str()).await?;

--- a/raftify/src/raft_node/mod.rs
+++ b/raftify/src/raft_node/mod.rs
@@ -1152,6 +1152,7 @@ impl<
                 tx_msg
                     .send(LocalResponseMsg::GetRawNode {
                         raw_node: Arc::new(Mutex::new(unsafe {
+                            #[allow(clippy::missing_transmute_annotations)]
                             std::mem::transmute(&self.raw_node)
                         })),
                     })

--- a/raftify/src/raft_node/mod.rs
+++ b/raftify/src/raft_node/mod.rs
@@ -1152,7 +1152,6 @@ impl<
                 tx_msg
                     .send(LocalResponseMsg::GetRawNode {
                         raw_node: Arc::new(Mutex::new(unsafe {
-                            #[allow(clippy::missing_transmute_annotations)]
                             std::mem::transmute(&self.raw_node)
                         })),
                     })


### PR DESCRIPTION
Implement pretty-print persisted log entries in a more readable table format using `comfy-table`