### PR TITLE
feat: Define custom `raftify-cli` --version command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,22 +775,22 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.33"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+checksum = "cbc3a6725e090f416f3c12d12605d90d6be4fde8bd762d236535ab02b388c70d"
 dependencies = [
  "const_format_proc_macros",
 ]
 
 [[package]]
 name = "const_format_proc_macros"
-version = "0.2.33"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+checksum = "e029ee8893eaad89abcb0885453d9555b8cb7982ac456ad044884725215bce42"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3328,12 +3328,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c655d81ff1114fb0dcdea9225ea9f0cc712a6f8d189378e82bdf62a473a64b"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff1a44b93f47b1bac19a27932f5c591e43d1ba357ee4f61526c8a25603f0eb1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,17 +2326,19 @@ dependencies = [
 
 [[package]]
 name = "raftify_cli"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "built",
  "clap 4.5.19",
  "comfy-table",
+ "const_format",
  "log",
  "raftify",
  "rocksdb",
  "serde",
  "serde_json",
  "slog",
+ "toml 0.8.19",
  "tonic-build",
 ]
 
@@ -3306,6 +3328,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/raftify-cli/Cargo.lock
+++ b/raftify-cli/Cargo.lock
@@ -460,6 +460,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc3a6725e090f416f3c12d12605d90d6be4fde8bd762d236535ab02b388c70d"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e029ee8893eaad89abcb0885453d9555b8cb7982ac456ad044884725215bce42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1629,17 +1649,19 @@ dependencies = [
 
 [[package]]
 name = "raftify_cli"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "built",
  "clap",
  "comfy-table",
+ "const_format",
  "log",
  "raftify",
  "rocksdb",
  "serde",
  "serde_json",
  "slog",
+ "toml 0.8.19",
  "tonic-build",
 ]
 

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "raftify_cli"
-version = "0.1.81"
+version = "0.1.82"
 edition = "2021"
 description = "Raftify CLI tool"
 license = "MIT/Apache-2.0"
+build = "build.rs"
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }
@@ -15,6 +16,7 @@ clap = { version = "4.5.18", features = ["derive"] }
 raftify = { version = "=0.1.81", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 rocksdb = "0.19.0"
 comfy-table = "7.1.1"
+cfmt = {version = "0.*", package = "const_format"}
 
 [lib]
 name = "raftify_cli"
@@ -23,3 +25,4 @@ path = "src/mod.rs"
 [build-dependencies]
 tonic-build = "0.9.2"
 built = "0.5"
+toml = "*"

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4.5.18", features = ["derive"] }
 raftify = { version = "=0.1.81", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 rocksdb = "0.19.0"
 comfy-table = "7.1.1"
-cfmt = {version = "0.*", package = "const_format"}
+cfmt = { version = "0.1.0", package = "const_format" }
 
 [lib]
 name = "raftify_cli"
@@ -25,4 +25,4 @@ path = "src/mod.rs"
 [build-dependencies]
 tonic-build = "0.9.2"
 built = "0.5"
-toml = "*"
+toml = "0.8.19"

--- a/raftify-cli/build.rs
+++ b/raftify-cli/build.rs
@@ -7,9 +7,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let read = fs::read_to_string(path)
         .expect("Failed to read Cargo.toml");
     let toml: Value = read.parse::<Value>().expect("Failed to parse Cargo.toml");
+
     if let Some(raftify_dep) = toml.get("dependencies").and_then(|deps| deps.get("raftify")) {
         let version = raftify_dep.get("version").unwrap().as_str().unwrap();
+        let features = raftify_dep.get("features").unwrap().as_array().unwrap().iter().map(|f| f.as_str().unwrap()).collect::<Vec<_>>().join(", ");
         println!("cargo:rustc-env=RAFTIFY_VERSION={}", &version[1..]);
+        println!("cargo:rustc-env=RAFTIFY_FEATURES={}", features);
     }
 
     built::write_built_file().expect("Failed to acquire build-time information");

--- a/raftify-cli/build.rs
+++ b/raftify-cli/build.rs
@@ -1,4 +1,17 @@
+use std::fs;
+use std::path::Path;
+use toml::Value;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = Path::new("Cargo.toml");
+    let read = fs::read_to_string(path)
+        .expect("Failed to read Cargo.toml");
+    let toml: Value = read.parse::<Value>().expect("Failed to parse Cargo.toml");
+    if let Some(raftify_dep) = toml.get("dependencies").and_then(|deps| deps.get("raftify")) {
+        let version = raftify_dep.get("version").unwrap().as_str().unwrap();
+        println!("cargo:rustc-env=RAFTIFY_VERSION={}", &version[1..]);
+    }
+
     built::write_built_file().expect("Failed to acquire build-time information");
     Ok(())
 }

--- a/raftify-cli/src/mod.rs
+++ b/raftify-cli/src/mod.rs
@@ -11,9 +11,16 @@ use raftify::{
     AbstractLogEntry, AbstractStateMachine, CustomFormatter, Result, StableStorage,
 };
 
+use cfmt::formatcp;
+
+const RAFTIFY_VERSION:&str = env!("RAFTIFY_VERSION");
+const VERSION_TEXT:&'static str = formatcp!("{PKG_VERSION}
+raftify {}", RAFTIFY_VERSION);
+
 #[derive(Parser)]
-#[command(name = "raftify")]
+#[command(name = PKG_NAME)]
 #[command(version = PKG_VERSION)]
+#[command(long_version = VERSION_TEXT)]
 #[command(author = PKG_AUTHORS)]
 #[command(about = PKG_DESCRIPTION)]
 struct App {

--- a/raftify-cli/src/mod.rs
+++ b/raftify-cli/src/mod.rs
@@ -13,16 +13,17 @@ use raftify::{
 
 use cfmt::formatcp;
 
-const RAFTIFY_VERSION:&str = env!("RAFTIFY_VERSION");
-const VERSION_TEXT:&'static str = formatcp!("{PKG_VERSION}
-raftify {}", RAFTIFY_VERSION);
+const RAFTIFY_VERSION: &str = env!("RAFTIFY_VERSION");
+const RAFTIFY_FEATURES: &str = env!("RAFTIFY_FEATURES");
+const VERSION_TEXT: &'static str = formatcp!("{PKG_VERSION}
+(Built with raftify {}, Enabled features: {})", RAFTIFY_VERSION, RAFTIFY_FEATURES);
 
 #[derive(Parser)]
 #[command(name = PKG_NAME)]
-#[command(version = PKG_VERSION)]
-#[command(long_version = VERSION_TEXT)]
 #[command(author = PKG_AUTHORS)]
 #[command(about = PKG_DESCRIPTION)]
+#[command(version = VERSION_TEXT)]
+#[command(long_version = VERSION_TEXT)]
 struct App {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Resolves: #155 
This PR improves the version display behavior in raftify-cli:

`-V` option: Now shows only the `raftify-cli` version, maintaining its original purpose.
`--version` option: Displays both the `raftify-cli` version and the `raftify` version, providing a more comprehensive version report for the CLI and the underlying library.