### PR TITLE
refactor: Replace `debug` commands with `describe` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "example-harness"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "raftify",
 ]
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "harness"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "bincode",
  "fs2",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "memstore-dynamic-members"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "memstore-example-harness"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "memstore-static-members"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "raftify"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 exclude = ["raft-rs", "raftify-cli"]
 
 [workspace.package]
-version = "0.1.81"
+version = "0.1.82"
 authors = ["Lablup Inc."]
 edition = "2021"
 description = "Experimental High level Raft framework"

--- a/README.md
+++ b/README.md
@@ -184,17 +184,55 @@ raft.propose(LogEntry::Insert {
 You can use a collection of CLI commands that let you inspect the data persisted in stable storage and the status of Raft Servers.
 
 ```
-❯ raftify-cli debug persisted ./logs/node-1
----- Persisted entries ----
-Key: 1, "Entry { context: [], data: [], entry_type: EntryNormal, index: 1, sync_log: false, term: 1 }"
-Key: 2, "Entry { context: [], data: ConfChange { change_type: AddNode, node_id: 2, context: [127.0.0.1:60062], id: 0 }, entry_type: EntryConfChange, index: 2, sync_log: false, term: 1 }"
-Key: 3, "Entry { context: [], data: ConfChange { change_type: AddNode, node_id: 3, context: [127.0.0.1:60063], id: 0 }, entry_type: EntryConfChange, index: 3, sync_log: false, term: 1 }"
+❯ raftify-cli describe logs ./logs/node-1
+┌───────┬────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬──────┐
+│ index ┆    type    ┆                                                             data                                                             ┆ term │
+╞═══════╪════════════╪══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════╪══════╡
+│   2   ┆ ConfChange ┆ ConfChangeV2 { transition: 0, changes: [ConfChangeSingle { change_type: AddNode, node_id: 2 }], context: [127.0.0.1:60062] } ┆   1  │
+├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│   3   ┆ ConfChange ┆ ConfChangeV2 { transition: 0, changes: [ConfChangeSingle { change_type: AddNode, node_id: 3 }], context: [127.0.0.1:60063] } ┆   1  │
+└───────┴────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴──────┘
+```
 
----- Metadata ----
-HardState { term: 1, vote: 1, commit: 3 }
-ConfState { voters: [1, 2, 3], learners: [], voters_outgoing: [], learners_next: [], auto_leave: false }
-Snapshot { data: HashStore(RwLock { data: {}, poisoned: false, .. }), metadata: Some(SnapshotMetadata { conf_state: Some(ConfState { voters: [1, 2, 3], learners: [], voters_outgoing: [], learners_next: [], auto_leave: false }), index: 1, term: 1 }) }
-Last index: 3
+```
+❯ raftify-cli describe metadata ./logs/node-1
+┌───────────┬─────────────────────────────────────┬──────────────────────────┐
+│           ┆ Field                               ┆ Value                    │
+╞═══════════╪═════════════════════════════════════╪══════════════════════════╡
+│ HardState ┆ term                                ┆ 1                        │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ vote                                ┆ 1                        │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ commit                              ┆ 3                        │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ ConfState ┆ voters                              ┆ {1, 2, 3}                │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ learners                            ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ voters_outgoing                     ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ learners_next                       ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ auto_leave                          ┆ false                    │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ Snapshot  ┆ data                                ┆ [0, 0, 0, 0, 0, 0, 0, 0] │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.index                      ┆ 3                        │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.term                       ┆ 1                        │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.conf_state.voters          ┆ {1, 2, 3}                │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.conf_state.learners        ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.conf_state.voters_outgoing ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.conf_state.learners_next   ┆ {}                       │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│           ┆ metadata.conf_state.auto_leave      ┆ false                    │
+├╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ LastIndex ┆ last index                          ┆ 3                        │
+└───────────┴─────────────────────────────────────┴──────────────────────────┘
 ```
 
 ## Bootstrapping from WAL

--- a/examples/memstore/Cargo.toml
+++ b/examples/memstore/Cargo.toml
@@ -26,8 +26,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.40", features = ["full"] }
 color-backtrace = "0.6.1"
-raftify = { version = "0.1.81" }
-raftify_cli = { version = "0.1.81" }
+raftify = { version = "0.1.82" }
+raftify_cli = { version = "0.1.82" }
 
 [features]
 default = ["heed_storage"]

--- a/raftify-cli/Cargo.lock
+++ b/raftify-cli/Cargo.lock
@@ -218,22 +218,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1118,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.8.3+7.4.4"
+version = "0.16.0+8.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b255ff04123fcc176162f56ed0c9cd42d8f357cf55b3fabeb60f7413741b3"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1128,6 +1128,7 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
+ "lz4-sys",
  "zstd-sys",
 ]
 
@@ -1180,6 +1181,16 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "matchit"
@@ -1320,12 +1331,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -1620,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "raftify"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5b03deb15cbf4d6ab568633af0651ff2c1df484fb840c8e9b82c258fff080d"
+checksum = "60b0fb37f65bdc30de7333b3ad60a29c24d9cbe9d7f732fbf30cfc609bb89c18"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1760,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/raftify-cli/Cargo.toml
+++ b/raftify-cli/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 slog = "2"
 built = "0.5"
 clap = { version = "4.5.18", features = ["derive"] }
-raftify = { version = "=0.1.81", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
+raftify = { version = "=0.1.82", features = ["heed_storage", "inmemory_storage", "rocksdb_storage"] }
 comfy-table = "7.1.1"
 cfmt = { version = "0.1.0", package = "const_format" }
 

--- a/raftify-cli/build.rs
+++ b/raftify-cli/build.rs
@@ -4,13 +4,24 @@ use toml::Value;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = Path::new("Cargo.toml");
-    let read = fs::read_to_string(path)
-        .expect("Failed to read Cargo.toml");
+    let read = fs::read_to_string(path).expect("Failed to read Cargo.toml");
     let toml: Value = read.parse::<Value>().expect("Failed to parse Cargo.toml");
 
-    if let Some(raftify_dep) = toml.get("dependencies").and_then(|deps| deps.get("raftify")) {
+    if let Some(raftify_dep) = toml
+        .get("dependencies")
+        .and_then(|deps| deps.get("raftify"))
+    {
         let version = raftify_dep.get("version").unwrap().as_str().unwrap();
-        let features = raftify_dep.get("features").unwrap().as_array().unwrap().iter().map(|f| f.as_str().unwrap()).collect::<Vec<_>>().join(", ");
+        let features = raftify_dep
+            .get("features")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f.as_str().unwrap())
+            .collect::<Vec<_>>()
+            .join(", ");
+
         println!("cargo:rustc-env=RAFTIFY_VERSION={}", &version[1..]);
         println!("cargo:rustc-env=RAFTIFY_FEATURES={}", features);
     }

--- a/raftify-cli/src/commands/describe.rs
+++ b/raftify-cli/src/commands/describe.rs
@@ -1,12 +1,8 @@
-use comfy_table::{
-    presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement, Table,
-};
+use comfy_table::{presets::UTF8_FULL, Cell, CellAlignment, ContentArrangement, Table};
 use core::panic;
 use serde_json::Value;
 use std::{
     collections::{BTreeSet, HashMap},
-    fs,
-    path::Path,
     sync::Arc,
 };
 
@@ -21,10 +17,10 @@ use raftify::{
     raft_service, ConfigBuilder, HeedStorage, Result, StableStorage, StorageType,
 };
 
-pub fn debug_persisted<LogStorage: StableStorage>(
+pub fn describe_entries<LogStorage: StableStorage>(
     path: &str,
     logger: slog::Logger,
-    print_as_table: bool,
+    print_raw_format: bool,
 ) -> Result<()> {
     let config = ConfigBuilder::new().log_dir(path.to_string()).build();
 
@@ -53,9 +49,11 @@ pub fn debug_persisted<LogStorage: StableStorage>(
         );
     }
 
-    println!("---- Persisted entries ----");
-
-    if print_as_table {
+    if print_raw_format {
+        for entry in entries.iter() {
+            println!("{}", format_entry(entry));
+        }
+    } else {
         let mut table = Table::new();
         table
             .load_preset(UTF8_FULL)
@@ -87,28 +85,54 @@ pub fn debug_persisted<LogStorage: StableStorage>(
             ]);
         }
         println!("{}", table);
-    } else {
-        for entry in entries.iter() {
-            println!("Key: {}, {:?}", entry.get_index(), format_entry(entry));
-        }
     }
 
     println!();
 
-    println!("---- Metadata ----");
+    Ok(())
+}
+
+pub fn describe_metadata<LogStorage: StableStorage>(
+    path: &str,
+    logger: slog::Logger,
+    print_raw_format: bool,
+) -> Result<()> {
+    let config = ConfigBuilder::new().log_dir(path.to_string()).build();
+
+    let storage = match LogStorage::STORAGE_TYPE {
+        StorageType::Heed => HeedStorage::create(
+            config.get_log_dir(),
+            &config,
+            Arc::new(Slogger {
+                slog: logger.clone(),
+            }),
+        )?,
+        StorageType::InMemory => {
+            panic!("InMemory storage does not support this feature");
+        }
+        _ => {
+            panic!("Unsupported storage type");
+        }
+    };
+
     let hard_state = storage.hard_state()?;
     let conf_state = storage.conf_state()?;
     let snapshot = storage.snapshot(0, 0)?;
     let last_index = storage.last_index()?;
 
-    if print_as_table {
+    if print_raw_format {
+        println!("{:?}", storage.hard_state()?);
+        println!("{:?}", storage.conf_state()?);
+        println!("{:?}", format_snapshot(&storage.snapshot(0, 0)?));
+        println!("Last index: {}", storage.last_index()?);
+    } else {
         let mut table = Table::new();
         table
             .load_preset(UTF8_FULL)
             .set_content_arrangement(ContentArrangement::Dynamic);
 
         table.set_header(vec![
-            Cell::new("Category"),
+            Cell::new(""),
             Cell::new("Field"),
             Cell::new("Value"),
         ]);
@@ -233,66 +257,12 @@ pub fn debug_persisted<LogStorage: StableStorage>(
         ]);
 
         println!("{}", table);
-    } else {
-        println!("{:?}", storage.hard_state()?);
-        println!("{:?}", storage.conf_state()?);
-        println!("{:?}", format_snapshot(&storage.snapshot(0, 0)?));
-        println!("Last index: {}", storage.last_index()?);
     }
 
     Ok(())
 }
 
-pub fn debug_persisted_all<LogStorage: StableStorage>(
-    path_str: &str,
-    logger: slog::Logger,
-    print_as_table: bool,
-) -> Result<()> {
-    let path = match fs::canonicalize(Path::new(&path_str)) {
-        Ok(absolute_path) => absolute_path,
-        Err(e) => {
-            panic!("Invalid path: {}", e);
-        }
-    };
-
-    if let Ok(subdirectories) = fs::read_dir(path.clone()) {
-        let mut dir_entries = vec![];
-        for dir_entry in subdirectories.filter_map(|e| e.ok()) {
-            let path = dir_entry.path();
-            if path.is_dir() {
-                if let Some(file_name) = path.file_name() {
-                    if let Some(name) = file_name.to_str() {
-                        if name.starts_with("node-") {
-                            dir_entries.push(name.to_owned());
-                        }
-                    }
-                }
-            }
-        }
-
-        if dir_entries.is_empty() {
-            panic!("Raft node log directory not found: \"{}\"", path.display());
-        }
-
-        dir_entries.sort();
-
-        for name in dir_entries {
-            println!("*----- {name} -----*");
-            debug_persisted::<LogStorage>(
-                &format!("{}/{}", path_str, name),
-                logger.clone(),
-                print_as_table,
-            )?;
-            println!();
-        }
-    } else {
-        panic!("Failed to read subdirectory: {}", path.display());
-    }
-
-    Ok(())
-}
-
-pub async fn debug_node(addr: &str) -> Result<()> {
+pub async fn describe_node(addr: &str) -> Result<()> {
     // TODO: Support TLS configuration
     let mut client = create_client(&addr, None).await?;
     let response = client.debug_node(raft_service::Empty {}).await?;
@@ -301,8 +271,4 @@ pub async fn debug_node(addr: &str) -> Result<()> {
 
     println!("{}", format_debugging_info(&parsed));
     Ok(())
-}
-
-pub async fn debug_entries(_addr: &str) -> Result<()> {
-    todo!()
 }

--- a/raftify-cli/src/commands/mod.rs
+++ b/raftify-cli/src/commands/mod.rs
@@ -1,1 +1,1 @@
-pub mod debug;
+pub mod describe;


### PR DESCRIPTION
Resolves #103.

After applying this PR, the existing commands will be changed as follows.

* `debug persisted` -> `describe logs`, `describe metadata`
    * For the reason behind the change, please refer to issue #103.
* Removed `debug persisted-all` (Since we can no longer make assumptions about the structure within the log directory)
* The `--table` flag for the existing persisted command has been removed. It now outputs in table format by default, and if you want to use the previous output format, please use the `--raw` flag.